### PR TITLE
ci: run clippy in the verify job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,17 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
         run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets
 
       - name: Test workspace
         run: cargo test --workspace


### PR DESCRIPTION
## What

Adds a `clippy` step to the CI `verify` job and installs the `clippy` component in the Rust toolchain, so lint feedback shows up on every push and pull request.

```yaml
- name: Clippy
  run: cargo clippy --workspace --all-targets
```

## Why

Clippy catches common mistakes and non-idiomatic Rust early, alongside the existing `cargo fmt --all --check` and `cargo test --workspace` steps. Warnings are reported but **do not fail the build** (no `-D warnings`), so this is purely additive and won't block CI on existing lints.

## Notes

Verified on a fork run: the clippy step passes on both `windows-latest` and `macos-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)