### PR TITLE
feat(ui): activate the step's primary button with Enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ from this file and posts it as the GitHub release body.
 
 ## [Unreleased]
 
+### Added
+
+- The wizard's primary action is now the window's default button, so pressing
+  Enter activates it from anywhere in the page (Next on the navigation steps,
+  Install on the review step) instead of only when a button already holds
+  focus. This matches the standard dialog convention on both macOS and Windows.
+  A disabled default button stays a no-op, so an invalid Target step or a
+  review step that can't install yet won't advance.
+
 ### Changed
 
 - A single unreachable upstream no longer blocks the entire update check.

--- a/crates/rabbit-ui-wxdragon/src/wx_app.rs
+++ b/crates/rabbit-ui-wxdragon/src/wx_app.rs
@@ -5247,6 +5247,17 @@ fn update_navigation(
         _ => false,
     });
     install.enable(step == REVIEW_STEP && can_install);
+    // Make the step's primary action the window's default button so Enter
+    // activates it regardless of which control holds focus (the standard
+    // dialog convention on both macOS and Windows). A disabled default
+    // button is a no-op on Enter, so an invalid Target step or a Review
+    // step that can't install yet won't advance — exactly what we want.
+    // Install is primary on Review; Next is primary everywhere else (it's
+    // disabled on the Done step, where Enter then does nothing).
+    match step {
+        REVIEW_STEP => install.set_default(),
+        _ => next.set_default(),
+    }
     // Language picker only matters on the Target step — switching languages
     // relaunches RABBIT and discards wizard progress, so a footer on later
     // pages would just be a tripwire.


### PR DESCRIPTION
## What

Make the wizard's primary action the window's **default button**, so pressing
**Enter** activates it from anywhere on the page — **Next** on the navigation
steps, **Install** on the review step — instead of only when a button already
holds focus.

This is done in `update_navigation` (the single chokepoint for every step
transition), so the default button always tracks the current step:

```rust
match step {
    REVIEW_STEP => install.set_default(),
    _ => next.set_default(),
}
```

## Why

Pressing Enter to advance a wizard is the standard dialog convention on both
macOS and Windows. Before this change, Enter only worked when the focus was
already on a button; with the focus on a list, choice, or text field (the
common case), Enter did nothing.

## Behavior notes

- `set_default()` is called after `enable()`, and a **disabled** default button
  is a no-op on Enter. So an invalid Target step or a review step that can't
  install yet won't advance — the existing enable/disable gating is preserved.
- On the Packages step, Enter activates Next; Space still toggles the
  checkboxes (list/tree controls don't consume Enter).
- Same behavior on macOS and Windows (no per-platform `cfg`).

## Testing

Built via CI and installed the macOS (arm64) artifact locally; verified Enter
advances each step and that disabled steps stay put.