### PR TITLE
feat(config): add REAPER Accessible (FR/EN) ReaPack repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.idea/
 /.vscode/
 /.claude/
+CLAUDE.local.md
 *.log
 *.tmp
 *.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ from this file and posts it as the GitHub release body.
 
 ## [Unreleased]
 
+### Added
+
+- Two new recommended ReaPack repository configuration steps from the
+  **REAPER Accessible** team: **REAPER Accessible (FR)**
+  (reaperaccessible/rap_fr, French-language resources) and **REAPER
+  Accessible (EN)** (reaperaccessible/rap_en, English-language resources).
+  Like the existing REAPER Accessibility step, they're offered after install
+  when ReaPack is present and wire the repositories into `reapack.ini`.
+
 ## [0.3.0] - 2026-06-30
 
 ### Added

--- a/crates/rabbit-core/src/configuration.rs
+++ b/crates/rabbit-core/src/configuration.rs
@@ -32,6 +32,24 @@ const REAPER_ACCESSIBILITY_REPACK_NAME: &str = "REAPER Accessibility";
 const REAPER_ACCESSIBILITY_REPACK_URL: &str =
     "https://github.com/Timtam/reapack/raw/master/index.xml";
 
+/// Stable id for the "configure REAPER Accessible (FR) ReaPack remote"
+/// step — the francophone resources repository from the
+/// `reaperaccessible` team.
+pub const CONFIG_REAPER_ACCESSIBLE_FR_REMOTE: &str = "reapack-add-reaper-accessible-fr-remote";
+/// Stable id for the "configure REAPER Accessible (EN) ReaPack remote"
+/// step — the anglophone resources repository from the
+/// `reaperaccessible` team.
+pub const CONFIG_REAPER_ACCESSIBLE_EN_REMOTE: &str = "reapack-add-reaper-accessible-en-remote";
+
+/// Display name / index URL for the `reaperaccessible/rap_fr` repo.
+const REAPER_ACCESSIBLE_FR_NAME: &str = "REAPER Accessible (FR)";
+const REAPER_ACCESSIBLE_FR_URL: &str =
+    "https://github.com/reaperaccessible/rap_fr/raw/main/index.xml";
+/// Display name / index URL for the `reaperaccessible/rap_en` repo.
+const REAPER_ACCESSIBLE_EN_NAME: &str = "REAPER Accessible (EN)";
+const REAPER_ACCESSIBLE_EN_URL: &str =
+    "https://github.com/reaperaccessible/rap_en/raw/main/index.xml";
+
 /// One unit of post-install configuration work the wizard / CLI can
 /// offer to the user. Steps are declarative — `kind` carries the data
 /// `apply_configuration_step` needs to actually perform the work.
@@ -126,17 +144,41 @@ pub enum ConfigurationStatus {
 /// All configuration steps RABBIT knows how to run. Hardcoded today;
 /// can move to JSON later if/when the catalogue grows.
 pub fn builtin_configuration_steps() -> Vec<ConfigurationStep> {
-    vec![ConfigurationStep {
-        id: CONFIG_REAPER_ACCESSIBILITY_REPACK_REMOTE.to_string(),
-        display_name_key: "config-reapack-reaper-accessibility-name".to_string(),
-        display_description_key: "config-reapack-reaper-accessibility-description".to_string(),
-        recommended: true,
-        requires_package_id: Some(PACKAGE_REAPACK.to_string()),
-        kind: ConfigurationStepKind::AddReapackRemote {
-            name: REAPER_ACCESSIBILITY_REPACK_NAME.to_string(),
-            url: REAPER_ACCESSIBILITY_REPACK_URL.to_string(),
+    vec![
+        ConfigurationStep {
+            id: CONFIG_REAPER_ACCESSIBILITY_REPACK_REMOTE.to_string(),
+            display_name_key: "config-reapack-reaper-accessibility-name".to_string(),
+            display_description_key: "config-reapack-reaper-accessibility-description".to_string(),
+            recommended: true,
+            requires_package_id: Some(PACKAGE_REAPACK.to_string()),
+            kind: ConfigurationStepKind::AddReapackRemote {
+                name: REAPER_ACCESSIBILITY_REPACK_NAME.to_string(),
+                url: REAPER_ACCESSIBILITY_REPACK_URL.to_string(),
+            },
         },
-    }]
+        ConfigurationStep {
+            id: CONFIG_REAPER_ACCESSIBLE_FR_REMOTE.to_string(),
+            display_name_key: "config-reapack-reaper-accessible-fr-name".to_string(),
+            display_description_key: "config-reapack-reaper-accessible-fr-description".to_string(),
+            recommended: true,
+            requires_package_id: Some(PACKAGE_REAPACK.to_string()),
+            kind: ConfigurationStepKind::AddReapackRemote {
+                name: REAPER_ACCESSIBLE_FR_NAME.to_string(),
+                url: REAPER_ACCESSIBLE_FR_URL.to_string(),
+            },
+        },
+        ConfigurationStep {
+            id: CONFIG_REAPER_ACCESSIBLE_EN_REMOTE.to_string(),
+            display_name_key: "config-reapack-reaper-accessible-en-name".to_string(),
+            display_description_key: "config-reapack-reaper-accessible-en-description".to_string(),
+            recommended: true,
+            requires_package_id: Some(PACKAGE_REAPACK.to_string()),
+            kind: ConfigurationStepKind::AddReapackRemote {
+                name: REAPER_ACCESSIBLE_EN_NAME.to_string(),
+                url: REAPER_ACCESSIBLE_EN_URL.to_string(),
+            },
+        },
+    ]
 }
 
 /// `true` when the on-disk state under `resource_path` already
@@ -290,6 +332,46 @@ mod tests {
                 assert_eq!(
                     url,
                     "https://github.com/Timtam/reapack/raw/master/index.xml"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn builtin_steps_include_reaper_accessible_fr_remote() {
+        let steps = builtin_configuration_steps();
+        let step = steps
+            .iter()
+            .find(|s| s.id == CONFIG_REAPER_ACCESSIBLE_FR_REMOTE)
+            .expect("REAPER Accessible (FR) ReaPack remote step is missing");
+        assert!(step.recommended);
+        assert_eq!(step.requires_package_id.as_deref(), Some(PACKAGE_REAPACK));
+        match &step.kind {
+            ConfigurationStepKind::AddReapackRemote { name, url } => {
+                assert_eq!(name, "REAPER Accessible (FR)");
+                assert_eq!(
+                    url,
+                    "https://github.com/reaperaccessible/rap_fr/raw/main/index.xml"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn builtin_steps_include_reaper_accessible_en_remote() {
+        let steps = builtin_configuration_steps();
+        let step = steps
+            .iter()
+            .find(|s| s.id == CONFIG_REAPER_ACCESSIBLE_EN_REMOTE)
+            .expect("REAPER Accessible (EN) ReaPack remote step is missing");
+        assert!(step.recommended);
+        assert_eq!(step.requires_package_id.as_deref(), Some(PACKAGE_REAPACK));
+        match &step.kind {
+            ConfigurationStepKind::AddReapackRemote { name, url } => {
+                assert_eq!(name, "REAPER Accessible (EN)");
+                assert_eq!(
+                    url,
+                    "https://github.com/reaperaccessible/rap_en/raw/main/index.xml"
                 );
             }
         }

--- a/locales/de-DE/rabbit.ftl
+++ b/locales/de-DE/rabbit.ftl
@@ -121,6 +121,10 @@ wizard-configuration-row-status-requires = erfordert { $package }
 wizard-configuration-row-status-already-applied = bereits angewendet
 config-reapack-reaper-accessibility-name = REAPER Accessibility ReaPack Repository
 config-reapack-reaper-accessibility-description = Fügt das REAPER Accessibility Repository von Toni Barth (https://github.com/Timtam/reapack/raw/master/index.xml) zu ReaPack hinzu, sodass Pakete daraus direkt verfügbar sind.
+config-reapack-reaper-accessible-fr-name = REAPER Accessible (FR) ReaPack Repository hinzufügen
+config-reapack-reaper-accessible-fr-description = Fügt das französischsprachige REAPER Accessible Repository (https://github.com/reaperaccessible/rap_fr/raw/main/index.xml) zu ReaPack hinzu. Öffne nach dem Hinzufügen das Menü Erweiterungen, ReaPack, Pakete durchsuchen, um die französischsprachigen Ressourcen von REAPER Accessible zu erhalten.
+config-reapack-reaper-accessible-en-name = REAPER Accessible (EN) ReaPack Repository hinzufügen
+config-reapack-reaper-accessible-en-description = Fügt das englischsprachige REAPER Accessible Repository (https://github.com/reaperaccessible/rap_en/raw/main/index.xml) zu ReaPack hinzu. Öffne nach dem Hinzufügen das Menü Erweiterungen, ReaPack, Pakete durchsuchen, um die englischsprachigen Ressourcen von REAPER Accessible zu erhalten.
 
 wizard-reapack-ack-heading = ReaPack-Spendenhinweis
 wizard-reapack-ack-body = ReaPack ist freie Software und steht unter der LGPL. Sein Autor Christian Fillion nimmt Spenden zur Unterstützung der Weiterentwicklung an. Spenden sind vollständig freiwillig und für die Nutzung von ReaPack oder RABBIT niemals erforderlich.

--- a/locales/en-US/rabbit.ftl
+++ b/locales/en-US/rabbit.ftl
@@ -121,6 +121,10 @@ wizard-configuration-row-status-requires = requires { $package }
 wizard-configuration-row-status-already-applied = already applied
 config-reapack-reaper-accessibility-name = Add Toni's REAPER Accessibility ReaPack repository
 config-reapack-reaper-accessibility-description = Adds Ttoni Barth's REAPER Accessibility ReaPack repository (https://github.com/Timtam/reapack/raw/master/index.xml). Once added, go to the Extensions menu, ReaPack, Browse Packages to get extra accessible scripts and plug-ins.
+config-reapack-reaper-accessible-fr-name = Add the REAPER Accessible (FR) ReaPack repository
+config-reapack-reaper-accessible-fr-description = Adds the REAPER Accessible French-language ReaPack repository (https://github.com/reaperaccessible/rap_fr/raw/main/index.xml). Once added, go to the Extensions menu, ReaPack, Browse Packages to get REAPER Accessible's French resources.
+config-reapack-reaper-accessible-en-name = Add the REAPER Accessible (EN) ReaPack repository
+config-reapack-reaper-accessible-en-description = Adds the REAPER Accessible English-language ReaPack repository (https://github.com/reaperaccessible/rap_en/raw/main/index.xml). Once added, go to the Extensions menu, ReaPack, Browse Packages to get REAPER Accessible's English resources.
 
 wizard-reapack-ack-heading = ReaPack donation notice
 wizard-reapack-ack-body = ReaPack is free software released under the LGPL. Its author Christian Fillion accepts optional donations to support continued development. Christian also maintains the SWS extensions and has landed code specifically to improve compatibility with OSARA in the past. Any support you can send has been well earned.

--- a/locales/fr-FR/rabbit.ftl
+++ b/locales/fr-FR/rabbit.ftl
@@ -121,6 +121,10 @@ wizard-configuration-row-status-requires = nécessite { $package }
 wizard-configuration-row-status-already-applied = déjà appliqué
 config-reapack-reaper-accessibility-name = Ajouter le dépôt ReaPack « REAPER Accessibility » de Toni
 config-reapack-reaper-accessibility-description = Ajoute le dépôt ReaPack « REAPER Accessibility » de Toni Barth (https://github.com/Timtam/reapack/raw/master/index.xml). Une fois ajouté, ouvrez le menu Extensions, ReaPack, Parcourir les paquets pour obtenir des scripts et des extensions accessibles supplémentaires.
+config-reapack-reaper-accessible-fr-name = Ajouter le dépôt ReaPack « REAPER Accessible (FR) »
+config-reapack-reaper-accessible-fr-description = Ajoute le dépôt ReaPack francophone de REAPER Accessible (https://github.com/reaperaccessible/rap_fr/raw/main/index.xml). Une fois ajouté, ouvrez le menu Extensions, ReaPack, Parcourir les paquets pour accéder aux ressources francophones de REAPER Accessible.
+config-reapack-reaper-accessible-en-name = Ajouter le dépôt ReaPack « REAPER Accessible (EN) »
+config-reapack-reaper-accessible-en-description = Ajoute le dépôt ReaPack anglophone de REAPER Accessible (https://github.com/reaperaccessible/rap_en/raw/main/index.xml). Une fois ajouté, ouvrez le menu Extensions, ReaPack, Parcourir les paquets pour accéder aux ressources anglophones de REAPER Accessible.
 
 wizard-reapack-ack-heading = Avis de don ReaPack
 wizard-reapack-ack-body = ReaPack est un logiciel libre publié sous licence LGPL. Son auteur, Christian Fillion, accepte des dons facultatifs pour soutenir la poursuite du développement. Christian maintient également les extensions SWS et a, par le passé, intégré du code spécifiquement destiné à améliorer la compatibilité avec OSARA. Tout soutien que vous pourrez lui apporter est amplement mérité.

--- a/locales/it-IT/rabbit.ftl
+++ b/locales/it-IT/rabbit.ftl
@@ -121,6 +121,10 @@ wizard-configuration-row-status-requires = richiede { $package }
 wizard-configuration-row-status-already-applied = già applicato
 config-reapack-reaper-accessibility-name = Aggiungi il repository ReaPack «REAPER Accessibility» di Toni
 config-reapack-reaper-accessibility-description = Aggiunge il repository ReaPack «REAPER Accessibility» di Toni Barth (https://github.com/Timtam/reapack/raw/master/index.xml). Una volta aggiunto, apri il menu Estensioni, ReaPack, Sfoglia pacchetti per ottenere ulteriori script ed estensioni accessibili.
+config-reapack-reaper-accessible-fr-name = Aggiungi il repository ReaPack «REAPER Accessible (FR)»
+config-reapack-reaper-accessible-fr-description = Aggiunge il repository ReaPack in lingua francese di REAPER Accessible (https://github.com/reaperaccessible/rap_fr/raw/main/index.xml). Una volta aggiunto, apri il menu Estensioni, ReaPack, Sfoglia pacchetti per accedere alle risorse in francese di REAPER Accessible.
+config-reapack-reaper-accessible-en-name = Aggiungi il repository ReaPack «REAPER Accessible (EN)»
+config-reapack-reaper-accessible-en-description = Aggiunge il repository ReaPack in lingua inglese di REAPER Accessible (https://github.com/reaperaccessible/rap_en/raw/main/index.xml). Una volta aggiunto, apri il menu Estensioni, ReaPack, Sfoglia pacchetti per accedere alle risorse in inglese di REAPER Accessible.
 
 wizard-reapack-ack-heading = Avviso di donazione ReaPack
 wizard-reapack-ack-body = ReaPack è software libero rilasciato sotto licenza LGPL. Il suo autore, Christian Fillion, accetta donazioni facoltative per sostenere lo sviluppo continuo. Christian gestisce anche le estensioni SWS e in passato ha integrato codice specificamente pensato per migliorare la compatibilità con OSARA. Qualsiasi sostegno tu possa offrirgli è ampiamente meritato.


### PR DESCRIPTION
## What

Adds two additional recommended post-install configuration steps that wire the **REAPER Accessible** team's ReaPack repositories into `reapack.ini`:

- **REAPER Accessible (FR)** — https://github.com/reaperaccessible/rap_fr (French-language resources)
- **REAPER Accessible (EN)** — https://github.com/reaperaccessible/rap_en (English-language resources)

Both are ReaPack repositories published by REAPER Accessible sharing accessibility-focused resources for REAPER (scripts for the media explorer, MIDI editor, language packs, helper functions, etc.). They complement the existing "REAPER Accessibility" (Timtam/reapack) step already offered by RABBIT.

## How

Both steps reuse the existing `ConfigurationStepKind::AddReapackRemote` machinery — no new plumbing:

- Added the two repo constants + `ConfigurationStep` entries in `builtin_configuration_steps()` (`rabbit-core/src/configuration.rs`), both `recommended: true` and requiring the ReaPack package (same as the existing step).
- Because the wizard tree, CLI `--config-step`/`--skip-config-step` handling, and the idempotent `upsert_remote` all iterate that list, the new repos are picked up everywhere automatically.
- Added i18n keys (`config-reapack-reaper-accessible-{fr,en}-{name,description}`) in all four locales (en-US, fr-FR, de-DE, it-IT).
- Added unit tests mirroring the existing REAPER Accessibility step test.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Notes

- Idempotent: re-running the wizard won't add duplicate remotes; already-configured repos are shown as such and greyed out.
- Both repos serve their `index.xml` from the `main` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)