### PR TITLE
feat(ui): show What's New in the package details pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ from this file and posts it as the GitHub release body.
 
 ## [Unreleased]
 
+### Added
+
+- The packages page's details pane now answers "what's new?": REAPER and
+  SWS show the newest section of their official changelogs, ReaPack shows
+  its release notes, and OSARA shows the latest snapshots' list of changes
+  — the feed OSARA's own updater reads, lightly cleaned for listening
+  rather than reading: developer-facing "dev:" commits are skipped,
+  repeated chore lines are collapsed, and trailing GitHub issue/PR
+  references are stripped. The notes are fetched together with the online
+  version check under a localized heading; packages whose feeds carry no
+  real notes (rolling snapshot releases) don't declare a notes source, and
+  if notes can't be fetched the pane simply keeps its usual contents. (#4)
+
 ### Changed
 
 - macOS self-updates now replace the whole `RABBIT.app` bundle with the

--- a/crates/rabbit-core/embedded/packages/10-reaper.json
+++ b/crates/rabbit-core/embedded/packages/10-reaper.json
@@ -23,6 +23,12 @@
       "pattern": "Version ([0-9][0-9.]*)"
     }
   },
+  "whats_new": {
+    "text_changelog": {
+      "url": "https://www.reaper.fm/whatsnew.txt",
+      "section_start": "^v[0-9]"
+    }
+  },
   "detectors": [
     "file_version_metadata"
   ],

--- a/crates/rabbit-core/embedded/packages/20-osara.json
+++ b/crates/rabbit-core/embedded/packages/20-osara.json
@@ -23,6 +23,12 @@
       "pointer": "/version"
     }
   },
+  "whats_new": {
+    "json_commits": {
+      "url": "https://osara.reaperaccessibility.com/snapshots/update.json",
+      "pointer": "/commits"
+    }
+  },
   "detectors": [
     "rabbit_receipt",
     "user_plugin_file",

--- a/crates/rabbit-core/embedded/packages/30-sws.json
+++ b/crates/rabbit-core/embedded/packages/30-sws.json
@@ -23,6 +23,12 @@
       "format": "{1}.{2}"
     }
   },
+  "whats_new": {
+    "text_changelog": {
+      "url": "https://raw.githubusercontent.com/reaper-oss/sws/master/whatsnew.txt",
+      "section_start": "^!v"
+    }
+  },
   "detectors": [
     "rabbit_receipt",
     "user_plugin_file",

--- a/crates/rabbit-core/embedded/packages/40-reapack.json
+++ b/crates/rabbit-core/embedded/packages/40-reapack.json
@@ -18,6 +18,11 @@
     "arm64-ec",
     "universal"
   ],
+  "whats_new": {
+    "github_release_body": {
+      "url": "https://api.github.com/repos/cfillion/reapack/releases/latest"
+    }
+  },
   "github_release": {
     "repo": "cfillion/reapack",
     "release": "latest",

--- a/crates/rabbit-core/src/latest.rs
+++ b/crates/rabbit-core/src/latest.rs
@@ -1,12 +1,14 @@
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeSet;
+use std::io::Read;
 
 use crate::error::{RabbitError, Result};
 use crate::hfs::{HfsListEntry, fetch_file_list, parse_get_file_list_response};
 use crate::package::{
     GithubReleaseSelector, GithubReleaseSpec, HfsListingSpec, VersionRule, VersionSource,
-    embedded_package_manifest,
+    WhatsNewRule, embedded_package_manifest,
 };
 use crate::plan::AvailablePackage;
 use crate::version::Version;
@@ -30,6 +32,14 @@ pub const FFMPEG_GYAN_VERSION_URL: &str =
 /// [`FFMPEG_SUPPORTED_MAJOR`].
 pub const FFMPEG_TORDONA_ARM64_RELEASES_URL: &str =
     "https://api.github.com/repos/tordona/ffmpeg-win-arm64/releases?per_page=100";
+
+/// Head-fetch budget for a `TextChangelog` What's-New source. REAPER's
+/// `whatsnew.txt` is the full release history (~1.4 MB) with the newest
+/// version on top, and one release section fits comfortably in the first few
+/// tens of KB — so the fetch asks for just this many bytes via a `Range`
+/// header (which reaper.fm honors) and caps the read regardless, for servers
+/// that ignore `Range` and reply with the whole file.
+const WHATS_NEW_HEAD_BYTES: u64 = 64 * 1024;
 
 /// FFmpeg major version that REAPER's video decoder is known to support.
 /// Bump this when a new REAPER release adds support for the next FFmpeg
@@ -78,9 +88,13 @@ pub fn fetch_latest_versions() -> Result<LatestVersionsReport> {
             continue;
         };
         match result {
+            // The batch path (CLI update check, offline-tolerant model load)
+            // only needs versions; What's-New notes are fetched by the GUI's
+            // per-package deferred check via fetch_latest_details_for_package.
             Ok(version) => packages.push(AvailablePackage {
                 package_id: spec.id.clone(),
                 version: Some(version),
+                whats_new: None,
             }),
             Err(error) => failures.push(LatestVersionFailure {
                 package_id: spec.id.clone(),
@@ -143,6 +157,23 @@ pub(crate) fn hfs_listing_error_url(spec: &HfsListingSpec) -> String {
 /// stream per-package results as they arrive instead of blocking on the full
 /// batch.
 pub fn fetch_latest_for_package(package_id: &str) -> Result<Version> {
+    fetch_latest_details_for_package(package_id).map(|details| details.version)
+}
+
+/// Latest-version details for one package: the resolved version plus the
+/// package's rendered What's-New notes, when it declares a `whats_new`
+/// source and that source resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LatestPackageDetails {
+    pub version: Version,
+    pub whats_new: Option<String>,
+}
+
+/// Like [`fetch_latest_for_package`], but also resolves the package's
+/// optional What's-New notes (the manifest's `whats_new` block). Notes are
+/// best-effort: any notes-side failure just yields `whats_new: None`, so
+/// release notes can never break the version check itself.
+pub fn fetch_latest_details_for_package(package_id: &str) -> Result<LatestPackageDetails> {
     let manifest = embedded_package_manifest();
     let spec = manifest
         .packages
@@ -156,12 +187,202 @@ pub fn fetch_latest_for_package(package_id: &str) -> Result<Version> {
     // Every package resolves its version data-driven: a `version` VersionRule
     // (REAPER/OSARA/SWS/FFmpeg), a `github_release` block (Surge XT, ReaKontrol,
     // ReaPack, app2clap), or an `hfs_listing` block (JAWS).
-    resolve_manifest_version(&client, spec).unwrap_or_else(|| {
+    let version = resolve_manifest_version(&client, spec).unwrap_or_else(|| {
         Err(RabbitError::RemoteData {
             url: String::new(),
             message: format!("no latest-version source configured for package {package_id}"),
         })
+    })?;
+    let whats_new = spec
+        .whats_new
+        .as_ref()
+        .and_then(|rule| resolve_whats_new_rule(&client, rule).ok());
+    Ok(LatestPackageDetails { version, whats_new })
+}
+
+/// Resolve a data-driven [`WhatsNewRule`] into the rendered notes text shown
+/// under the What's-New heading in the wizard's package-details pane.
+pub fn resolve_whats_new_rule(client: &Client, rule: &WhatsNewRule) -> Result<String> {
+    match rule {
+        WhatsNewRule::JsonCommits { url, pointer } => {
+            let body = http_get_text(client, url)?;
+            resolve_json_commits(&body, url, pointer)
+        }
+        WhatsNewRule::TextChangelog { url, section_start } => {
+            let body = http_get_text_head(client, url, WHATS_NEW_HEAD_BYTES)?;
+            resolve_changelog_head_section(&body, url, section_start)
+        }
+        WhatsNewRule::GithubReleaseBody { url } => {
+            let body = http_get_text(client, url)?;
+            resolve_github_release_body(&body, url)
+        }
+    }
+}
+
+/// Release-body side of [`resolve_whats_new_rule`], split out so it's
+/// unit-testable on a fixture body without an HTTP fetch. Reads the
+/// release's `body` string and renders Markdown list markers (`- `, `* `) as
+/// the same bullets the commit list uses, leaving other lines verbatim.
+pub(crate) fn resolve_github_release_body(body: &str, url: &str) -> Result<String> {
+    let value: Value = serde_json::from_str(body).map_err(|source| RabbitError::RemoteData {
+        url: url.to_string(),
+        message: source.to_string(),
+    })?;
+    let notes = value
+        .pointer("/body")
+        .and_then(Value::as_str)
+        .ok_or_else(|| RabbitError::RemoteData {
+            url: url.to_string(),
+            message: "missing release body".to_string(),
+        })?;
+    let lines: Vec<String> = notes
+        .lines()
+        .map(|line| {
+            let line = line.trim_end();
+            match line.strip_prefix("- ").or_else(|| line.strip_prefix("* ")) {
+                Some(item) => format!("• {item}"),
+                None => line.to_string(),
+            }
+        })
+        .collect();
+    let rendered = lines.join("\n");
+    let trimmed = rendered.trim();
+    if trimmed.is_empty() {
+        return Err(RabbitError::RemoteData {
+            url: url.to_string(),
+            message: "release body is empty".to_string(),
+        });
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Commit-list side of [`resolve_whats_new_rule`], split out so it's
+/// unit-testable on a fixture body without an HTTP fetch. Reads the array of
+/// `[sha, message]` pairs at `pointer` and renders one bulleted line per
+/// commit, keeping only each message's first line — full bodies can run to
+/// paragraphs, and the details pane wants a scannable list.
+///
+/// The list is lightly cleaned for end users (a screen reader reads every
+/// character out loud): trailing GitHub issue/PR references are stripped,
+/// commits using OSARA's `dev:` prefix convention for developer-facing work
+/// are skipped, and repeated chore lines ("Update translations.") keep only
+/// their first occurrence.
+pub(crate) fn resolve_json_commits(body: &str, url: &str, pointer: &str) -> Result<String> {
+    let value: Value = serde_json::from_str(body).map_err(|source| RabbitError::RemoteData {
+        url: url.to_string(),
+        message: source.to_string(),
+    })?;
+    let entries = value
+        .pointer(pointer)
+        .and_then(Value::as_array)
+        .ok_or_else(|| RabbitError::RemoteData {
+            url: url.to_string(),
+            message: format!("missing commit array at JSON pointer {pointer:?}"),
+        })?;
+    let mut seen = BTreeSet::new();
+    let mut lines: Vec<String> = Vec::new();
+    for message in entries
+        .iter()
+        .filter_map(|entry| entry.as_array()?.get(1)?.as_str())
+    {
+        let Some(first_line) = message.lines().next() else {
+            continue;
+        };
+        let cleaned = strip_trailing_issue_refs(first_line.trim());
+        if cleaned.is_empty()
+            || cleaned
+                .get(..4)
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("dev:"))
+        {
+            continue;
+        }
+        if seen.insert(cleaned.to_string()) {
+            lines.push(format!("• {cleaned}"));
+        }
+    }
+    if lines.is_empty() {
+        return Err(RabbitError::RemoteData {
+            url: url.to_string(),
+            message: format!("no commit messages at JSON pointer {pointer:?}"),
+        });
+    }
+    Ok(lines.join("\n"))
+}
+
+/// Strip GitHub issue/PR references from the end of a commit's first line —
+/// `(#1431)`, `(issue #1410, PR #1416)`, `Closes #1424`, `Fixes #997.` —
+/// repeatedly, so a combination like `(#1426) Closes #1424` fully unwinds.
+/// The references are pure noise when read by a screen reader; anyone
+/// chasing a change down goes to the repository anyway. Mid-sentence
+/// references are left alone.
+fn strip_trailing_issue_refs(line: &str) -> &str {
+    let mut cleaned = line.trim_end();
+    loop {
+        let before = cleaned;
+        if let Some(found) = trailing_paren_ref_regex().find(cleaned) {
+            cleaned = cleaned[..found.start()].trim_end();
+        }
+        if let Some(found) = trailing_bare_ref_regex().find(cleaned) {
+            cleaned = cleaned[..found.start()].trim_end();
+        }
+        if cleaned == before {
+            return cleaned;
+        }
+    }
+}
+
+/// A trailing parenthesized reference group: `(#1431)`, `(issue #1401, PR
+/// #1402)` — only digits and reference keywords inside the parentheses, so a
+/// meaningful trailing parenthetical is never eaten.
+fn trailing_paren_ref_regex() -> &'static Regex {
+    static TRAILING_PAREN_REF: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    TRAILING_PAREN_REF.get_or_init(|| {
+        Regex::new(r"(?i)\s*\(\s*(?:(?:issue|pr|closes|fixes|re)?\s*#\d+\s*,?\s*)+\)\.?\s*$")
+            .expect("static trailing paren ref regex is valid")
     })
+}
+
+/// A trailing bare reference: `Closes #1424`, `Fixes #997.`, `Re #1406`.
+fn trailing_bare_ref_regex() -> &'static Regex {
+    static TRAILING_BARE_REF: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    TRAILING_BARE_REF.get_or_init(|| {
+        Regex::new(r"(?i)\s*\b(?:closes|fixes|re)\s+#\d+\.?\s*$")
+            .expect("static trailing bare ref regex is valid")
+    })
+}
+
+/// Changelog side of [`resolve_whats_new_rule`], split out so it's
+/// unit-testable on a fixture body. Cuts the newest release's section out of
+/// a newest-first plain-text changelog: from the first line matching
+/// `section_start` up to, excluding, the next matching line. When no second
+/// header follows (e.g. the head-capped fetch cut it off), the rest of the
+/// body is kept.
+pub(crate) fn resolve_changelog_head_section(
+    body: &str,
+    url: &str,
+    section_start: &str,
+) -> Result<String> {
+    // `(?m:…)` forces multi-line mode so `^` in the manifest pattern anchors
+    // to line starts without every manifest having to remember the flag.
+    let regex =
+        Regex::new(&format!("(?m:{section_start})")).map_err(|err| RabbitError::RemoteData {
+            url: url.to_string(),
+            message: format!("invalid section_start regex {section_start:?}: {err}"),
+        })?;
+    let start = regex
+        .find(body)
+        .ok_or_else(|| RabbitError::RemoteData {
+            url: url.to_string(),
+            message: format!("section pattern {section_start:?} did not match"),
+        })?
+        .start();
+    let section = &body[start..];
+    let end = regex
+        .find_iter(section)
+        .find(|next| next.start() > 0)
+        .map(|next| next.start())
+        .unwrap_or(section.len());
+    Ok(section[..end].trim_end().to_string())
 }
 
 /// Resolve a data-driven [`VersionRule`]: fetch its URL and extract a version
@@ -375,6 +596,42 @@ fn http_get_text(client: &Client, url: &str) -> Result<String> {
         url: url.to_string(),
         source,
     })
+}
+
+/// GET at most `max_bytes` of `url`. The request carries a `Range` header so
+/// a cooperating server (reaper.fm does) only sends the head; the reader is
+/// capped at `max_bytes` regardless, so a server that ignores `Range` and
+/// replies 200 with the full body still costs at most one buffer. When the
+/// cap was actually hit, the final — almost certainly truncated — line is
+/// dropped so callers only ever see whole lines.
+fn http_get_text_head(client: &Client, url: &str, max_bytes: u64) -> Result<String> {
+    let request = crate::http::maybe_apply_github_auth(client.get(url), url)
+        .header(reqwest::header::RANGE, format!("bytes=0-{}", max_bytes - 1));
+    let response = request
+        .send()
+        .and_then(|response| response.error_for_status())
+        .map_err(|source| RabbitError::Http {
+            url: url.to_string(),
+            source,
+        })?;
+
+    let mut body = Vec::new();
+    response
+        .take(max_bytes)
+        .read_to_end(&mut body)
+        .map_err(|source| RabbitError::RemoteData {
+            url: url.to_string(),
+            message: source.to_string(),
+        })?;
+    let capped = body.len() as u64 == max_bytes;
+    let mut text = String::from_utf8_lossy(&body).into_owned();
+    if capped {
+        match text.rfind('\n') {
+            Some(last_newline) => text.truncate(last_newline),
+            None => text.clear(),
+        }
+    }
+    Ok(text)
 }
 
 /// The GitHub API URL a [`GithubReleaseSpec`] reads — `/releases/latest`
@@ -642,6 +899,110 @@ mod tests {
                 r#"{"version":"not-a-version"}"#,
                 OSARA_UPDATE_URL,
                 "/version"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn renders_osara_commits_as_a_cleaned_bulleted_list() {
+        // OSARA's update.json `commits` is an array of [sha, message] pairs.
+        // The rendering keeps each message's first line only (CRLF bodies can
+        // run to paragraphs), strips trailing GitHub issue/PR references,
+        // skips OSARA's "dev:"-prefixed internal commits, and keeps only the
+        // first occurrence of repeated chore lines.
+        let body = concat!(
+            r#"{"version":"2026.8.1.2278,857265da","commits":["#,
+            r#"["857265da","Fix the slider. (#1431)\r\n\r\nLong body paragraph."],"#,
+            r#"["342b988d","dev: Logging improvements. (#1430)"],"#,
+            r#"["64ee308c","Add vertical zoom feedback (#1426) Closes #1424"],"#,
+            r#"["11111111","Update translations."],"#,
+            r#"["22222222","Map lang pack to nb_NO translation. Fixes #997."],"#,
+            r#"["33333333","Update translations."],"#,
+            r#"["44444444","Localise send parameters. (issue #1411, PR #1412)"]"#,
+            "]}"
+        );
+        let notes = super::resolve_json_commits(body, OSARA_UPDATE_URL, "/commits").unwrap();
+        assert_eq!(
+            notes,
+            "• Fix the slider.\n\
+             • Add vertical zoom feedback\n\
+             • Update translations.\n\
+             • Map lang pack to nb_NO translation.\n\
+             • Localise send parameters."
+        );
+
+        // A mid-sentence reference is not a trailing one — left alone.
+        let body = r#"{"commits":[["aa","Fix the #5 slot (see #12) in the mixer"]]}"#;
+        let notes = super::resolve_json_commits(body, OSARA_UPDATE_URL, "/commits").unwrap();
+        assert_eq!(notes, "• Fix the #5 slot (see #12) in the mixer");
+
+        // A missing pointer and an empty list are errors (the caller treats
+        // any notes-side error as "no What's-New section"), not panics.
+        let missing = super::resolve_json_commits(r#"{"nope":1}"#, OSARA_UPDATE_URL, "/commits");
+        assert!(missing.is_err());
+        let empty = super::resolve_json_commits(r#"{"commits":[]}"#, OSARA_UPDATE_URL, "/commits");
+        assert!(empty.is_err());
+    }
+
+    #[test]
+    fn renders_reapack_release_body_with_bullets() {
+        // ReaPack's release body is a plain Markdown bullet list; markers
+        // are normalized to the same bullets the OSARA commit list uses,
+        // other lines stay verbatim.
+        let url = "https://api.github.com/repos/cfillion/reapack/releases/latest";
+        let body = concat!(
+            r#"{"tag_name":"v1.2.6","body":"#,
+            r#""- Add Crossfade Editor support\r\n- Update filter synonyms\r\nSee the manual.""#,
+            "}"
+        );
+        let notes = super::resolve_github_release_body(body, url).unwrap();
+        assert_eq!(
+            notes,
+            "• Add Crossfade Editor support\n• Update filter synonyms\nSee the manual."
+        );
+
+        // A missing or blank body is an error, not a panic — packages with
+        // boilerplate rolling-release bodies just don't declare this source.
+        let no_body = super::resolve_github_release_body(r#"{"tag_name":"v1"}"#, url);
+        assert!(no_body.is_err());
+        let blank = super::resolve_github_release_body(r#"{"body":"  \r\n "}"#, url);
+        assert!(blank.is_err());
+    }
+
+    #[test]
+    fn cuts_newest_section_from_reaper_whatsnew() {
+        // whatsnew.txt is newest-first; the notes are the first section only,
+        // header line included, trailing blank lines trimmed.
+        let body = "v7.78 - July 18\n  + Fix one\n  + Fix two\n\nv7.77 - June 2\n  + Older\n";
+        let notes = super::resolve_changelog_head_section(
+            body,
+            "https://www.reaper.fm/whatsnew.txt",
+            "^v[0-9]",
+        )
+        .unwrap();
+        assert_eq!(notes, "v7.78 - July 18\n  + Fix one\n  + Fix two");
+    }
+
+    #[test]
+    fn changelog_section_without_following_header_keeps_the_rest() {
+        // The head-capped fetch can cut the body before the next version
+        // header; everything after the first header is then the section.
+        let body = "Preamble line\nv7.78 - July 18 2026\n  + Fix one thing";
+        let notes = super::resolve_changelog_head_section(
+            body,
+            "https://www.reaper.fm/whatsnew.txt",
+            "^v[0-9]",
+        )
+        .unwrap();
+        assert_eq!(notes, "v7.78 - July 18 2026\n  + Fix one thing");
+
+        // No matching header at all is an error, not a panic.
+        assert!(
+            super::resolve_changelog_head_section(
+                "nothing here",
+                "https://www.reaper.fm/whatsnew.txt",
+                "^v[0-9]",
             )
             .is_err()
         );

--- a/crates/rabbit-core/src/localization.rs
+++ b/crates/rabbit-core/src/localization.rs
@@ -364,6 +364,28 @@ mod tests {
     }
 
     #[test]
+    fn whats_new_heading_formats_in_every_embedded_locale() {
+        // The heading is composed with .format() at row-build time without a
+        // missing-key fallback, so a locale that forgets the key would show
+        // the raw key id in the details pane. Guard all four by hand since
+        // there is no automated locale-parity check.
+        for &locale in embedded_locales() {
+            let localizer = Localizer::embedded(locale).unwrap();
+            let message =
+                localizer.format("wizard-package-whats-new-heading", &[("package", "OSARA")]);
+            assert!(
+                !message.missing,
+                "locale {locale} is missing wizard-package-whats-new-heading"
+            );
+            assert!(
+                message.value.contains("OSARA"),
+                "locale {locale} should interpolate the package name, got {:?}",
+                message.value
+            );
+        }
+    }
+
+    #[test]
     fn loads_embedded_german_messages() {
         let localizer = Localizer::embedded("de-DE").unwrap();
 

--- a/crates/rabbit-core/src/package.rs
+++ b/crates/rabbit-core/src/package.rs
@@ -119,6 +119,8 @@ pub struct EmbeddedPackageSpec {
     #[serde(default)]
     pub version: Option<VersionRule>,
     #[serde(default)]
+    pub whats_new: Option<WhatsNewRule>,
+    #[serde(default)]
     pub detectors: Vec<PackageDetector>,
     #[serde(default)]
     pub install_steps: Vec<InstallStep>,
@@ -489,6 +491,38 @@ fn default_capture_format() -> String {
     "{1}".to_string()
 }
 
+/// Data-driven What's-New (release notes) discovery for the wizard's
+/// package-details pane. Like [`VersionRule`], each variant fetches a URL and
+/// extracts human-readable notes, so a package's notes side is manifest data
+/// rather than a per-package Rust parser. Notes are best-effort: a fetch or
+/// parse failure leaves the pane without a What's-New section instead of
+/// failing the version check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WhatsNewRule {
+    /// Fetch `url` (JSON) and read the commit list at `pointer` (an RFC 6901
+    /// JSON pointer): an array of `[sha, message]` pairs, newest first.
+    /// Rendered as one bulleted line per commit, keeping only each message's
+    /// first line (full bodies can run to paragraphs). Covers OSARA's
+    /// `update.json` `commits` field — the same feed OSARA's own updater
+    /// shows as its list of changes.
+    JsonCommits { url: String, pointer: String },
+    /// Fetch the head of `url` — a plain-text changelog with the newest
+    /// release first — and cut the first section: from the first line
+    /// matching the `section_start` regex (compiled in multi-line mode) up
+    /// to, excluding, the next matching line. Covers REAPER's
+    /// `whatsnew.txt` (`v7.78 - July 18 2026` section headers) and SWS's
+    /// (`!v2.14.0.7 featured build …` headers).
+    TextChangelog { url: String, section_start: String },
+    /// Fetch `url` (a GitHub release API endpoint, typically the same one
+    /// the package's `github_release` block reads) and render the release's
+    /// `body` — the notes the maintainer wrote. Covers ReaPack. Only declare
+    /// this for packages whose releases carry real notes: rolling snapshot
+    /// tags (ReaKontrol, Surge XT, app2clap) have a static boilerplate body
+    /// that would be worse than showing nothing.
+    GithubReleaseBody { url: String },
+}
+
 /// A detection probe. Listed in `detectors` per package and run by the
 /// detection engine in order, so the manifest declares both *which* probes
 /// apply and their fallback order. `RabbitReceipt` (authoritative) and
@@ -724,6 +758,17 @@ pub fn validate_package_spec(spec: &EmbeddedPackageSpec) -> Result<(), String> {
         }
     }
 
+    // A broken `whats_new` regex would otherwise only surface at fetch time,
+    // where notes failures are deliberately silent — so a first-party typo
+    // would quietly disable the What's-New pane instead of failing loudly.
+    if let Some(WhatsNewRule::TextChangelog { section_start, .. }) = &spec.whats_new
+        && let Err(err) = regex::Regex::new(section_start)
+    {
+        return Err(format!(
+            "whats_new section_start regex {section_start:?} is invalid: {err}"
+        ));
+    }
+
     Ok(())
 }
 
@@ -846,9 +891,10 @@ mod tests {
         BackupPolicy, GithubArtifactKind, GithubReleaseSelector, HostCapabilities, HostCapability,
         InstallDestination, InstallStep, PACKAGE_JAWS_SCRIPTS, PACKAGE_OSARA, PACKAGE_REAKONTROL,
         PACKAGE_REAPACK, PACKAGE_REAPER, PACKAGE_SURGE_XT, PACKAGE_SWS, PackageDetector,
-        PackageKind, SupportedPlatform, VersionRule, VersionSource, builtin_package_specs,
-        default_desired_package_ids_for_host, embedded_package_manifest,
-        embedded_package_manifest_bytes, package_specs_by_id, parse_package_manifest,
+        PackageKind, SupportedPlatform, VersionRule, VersionSource, WhatsNewRule,
+        builtin_package_specs, default_desired_package_ids_for_host, embedded_package_manifest,
+        embedded_package_manifest_bytes, package_specs_by_id, parse_embedded_package_spec,
+        parse_package_manifest, validate_package_spec,
     };
 
     #[test]
@@ -916,6 +962,11 @@ mod tests {
         // REAPER's version is a data-driven HTML rule and its artifact is a
         // data-driven `http_artifact` page scrape.
         assert!(matches!(reaper.version, Some(VersionRule::Html { .. })));
+        // REAPER's What's-New is the newest section of whatsnew.txt.
+        assert!(matches!(
+            reaper.whats_new,
+            Some(WhatsNewRule::TextChangelog { .. })
+        ));
         let reaper_http = reaper.http_artifact.as_ref().expect("reaper http_artifact");
         assert!(reaper_http.targets.iter().any(|target| matches!(
             (target.platform, target.artifact_kind),
@@ -934,6 +985,12 @@ mod tests {
             .unwrap();
         assert_eq!(osara.package_kind, PackageKind::UserPluginBinary);
         assert!(matches!(osara.version, Some(VersionRule::Json { .. })));
+        // OSARA's What's-New is the commit list in the same update.json the
+        // version rule reads.
+        assert!(matches!(
+            osara.whats_new,
+            Some(WhatsNewRule::JsonCommits { .. })
+        ));
         assert!(osara.http_artifact.is_some());
         assert_eq!(osara.backup_policy, BackupPolicy::BackupOverwrittenFiles);
         assert!(osara.detectors.contains(&PackageDetector::UserPluginFile));
@@ -942,6 +999,28 @@ mod tests {
                 .install_steps
                 .contains(&InstallStep::CopyUserPluginBinary)
         );
+        // SWS reuses the generic text-changelog What's-New engine (`!vX.Y`
+        // section headers) — pure manifest data, no SWS-specific Rust.
+        let sws = manifest
+            .packages
+            .iter()
+            .find(|package| package.id == PACKAGE_SWS)
+            .unwrap();
+        assert!(matches!(
+            sws.whats_new,
+            Some(WhatsNewRule::TextChangelog { .. })
+        ));
+        // ReaPack's What's-New is the body of the same GitHub release its
+        // version already reads.
+        let reapack = manifest
+            .packages
+            .iter()
+            .find(|package| package.id == PACKAGE_REAPACK)
+            .unwrap();
+        assert!(matches!(
+            reapack.whats_new,
+            Some(WhatsNewRule::GithubReleaseBody { .. })
+        ));
         // The per-package files were gathered at compile time and are
         // non-empty (build.rs picked them up).
         assert!(embedded_package_manifest_bytes() > 0);
@@ -1001,6 +1080,36 @@ mod tests {
         assert!(surge.detectors.contains(&PackageDetector::RabbitReceipt));
         assert!(surge.detectors.contains(&PackageDetector::SurgeVendorFiles));
         assert!(surge.user_plugin_prefixes.is_empty());
+    }
+
+    #[test]
+    fn validation_rejects_an_invalid_whats_new_regex() {
+        // Notes-side failures are deliberately silent at fetch time, so a
+        // broken first-party `section_start` regex must fail loudly at
+        // manifest load instead of quietly disabling the What's-New pane.
+        let spec = parse_embedded_package_spec(
+            r#"{
+                "id": "demo",
+                "display_name": "Demo",
+                "display_name_key": "package-demo",
+                "display_description_key": "package-demo-description",
+                "recommended": false,
+                "user_plugin_prefixes": [],
+                "user_plugin_suffixes": { "windows": [], "macos": [] },
+                "whats_new": {
+                    "text_changelog": {
+                        "url": "https://example.com/whatsnew.txt",
+                        "section_start": "(["
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        let message = validate_package_spec(&spec).unwrap_err();
+        assert!(
+            message.contains("section_start"),
+            "expected the error to name the offending field, got {message:?}"
+        );
     }
 
     #[test]

--- a/crates/rabbit-core/src/plan.rs
+++ b/crates/rabbit-core/src/plan.rs
@@ -11,6 +11,12 @@ use crate::version::Version;
 pub struct AvailablePackage {
     pub package_id: String,
     pub version: Option<Version>,
+    /// Rendered What's-New notes for the available version, when the package
+    /// declares a `whats_new` source and the wizard's deferred check resolved
+    /// it. Carried next to the version so the package-details pane can show
+    /// them; the planner itself ignores this field.
+    #[serde(default)]
+    pub whats_new: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -179,6 +185,7 @@ mod tests {
         let available = vec![AvailablePackage {
             package_id: PACKAGE_OSARA.to_string(),
             version: Some(Version::parse("2024.2").unwrap()),
+            whats_new: None,
         }];
         let desired = vec![PACKAGE_OSARA.to_string()];
 
@@ -206,6 +213,7 @@ mod tests {
         let available = vec![AvailablePackage {
             package_id: PACKAGE_REAPACK.to_string(),
             version: Some(Version::parse("1.2.6").unwrap()),
+            whats_new: None,
         }];
         let desired = vec![PACKAGE_REAPACK.to_string()];
 
@@ -231,6 +239,7 @@ mod tests {
         let available = vec![AvailablePackage {
             package_id: PACKAGE_REAPER.to_string(),
             version: Some(Version::parse("7.70").unwrap()),
+            whats_new: None,
         }];
 
         let plan = build_install_plan(Some(installation), &[], &desired, &available);
@@ -279,6 +288,7 @@ mod tests {
         let available = vec![AvailablePackage {
             package_id: PACKAGE_REAPER.to_string(),
             version: Some(Version::parse("7.70").unwrap()),
+            whats_new: None,
         }];
 
         let plan = build_install_plan(Some(installation), &[], &desired, &available);

--- a/crates/rabbit-ui-wxdragon/src/lib.rs
+++ b/crates/rabbit-ui-wxdragon/src/lib.rs
@@ -573,6 +573,7 @@ fn model_from_plan_with_options(
         architecture,
         &package_specs,
         &plan.actions,
+        &available_packages,
         &host,
     );
     let target_resource_path = selected_target_index
@@ -1327,6 +1328,7 @@ pub fn wizard_package_plan_for_target_with_available(
         model.architecture,
         &package_specs,
         &plan.actions,
+        available_packages,
         &host,
     );
 
@@ -2680,11 +2682,21 @@ fn package_rows(
     architecture: Architecture,
     package_specs: &[PackageSpec],
     actions: &[PlanAction],
+    available_packages: &[AvailablePackage],
     host: &HostCapabilities,
 ) -> Vec<PackageRow> {
     let specs_by_id: BTreeMap<_, _> = package_specs
         .iter()
         .map(|spec| (spec.id.as_str(), spec))
+        .collect();
+    let whats_new_by_id: BTreeMap<_, _> = available_packages
+        .iter()
+        .filter_map(|available| {
+            available
+                .whats_new
+                .as_deref()
+                .map(|notes| (available.package_id.as_str(), notes))
+        })
         .collect();
     actions
         .iter()
@@ -2754,6 +2766,22 @@ fn package_rows(
                 summary.clone()
             } else {
                 format!("{summary}\n\n{description}")
+            };
+            // The available version's What's-New notes (resolved by the
+            // deferred version check for packages that declare a source)
+            // follow under a localized heading, so the pane answers "what
+            // changed upstream?" without a trip to the package's website.
+            let details = match whats_new_by_id.get(action.package_id.as_str()) {
+                Some(notes) => {
+                    let heading = localizer
+                        .format(
+                            "wizard-package-whats-new-heading",
+                            &[("package", display_name.as_str())],
+                        )
+                        .value;
+                    format!("{details}\n\n{heading}\n{notes}")
+                }
+                None => details,
             };
             PackageRow {
                 package_id: action.package_id.clone(),
@@ -3188,7 +3216,7 @@ mod tests {
         PACKAGE_FFMPEG, PACKAGE_OSARA, PACKAGE_REAKONTROL, PACKAGE_REAPACK, PACKAGE_REAPER,
         PACKAGE_SWS, builtin_package_specs,
     };
-    use rabbit_core::plan::{InstallPlan, PlanAction, PlanActionKind};
+    use rabbit_core::plan::{AvailablePackage, InstallPlan, PlanAction, PlanActionKind};
     use rabbit_core::preflight::PreflightReport;
     use rabbit_core::resource::ResourceInitReport;
     use rabbit_core::setup::SetupReport;
@@ -3723,6 +3751,7 @@ mod tests {
                 available_version: Some(Version::parse("2026.2").unwrap()),
                 reason: "Missing".to_string(),
             }],
+            &[],
             &host,
         );
         assert!(
@@ -3746,6 +3775,7 @@ mod tests {
                 available_version: Some(Version::parse("2026.2").unwrap()),
                 reason: "Missing".to_string(),
             }],
+            &[],
             &HostCapabilities::default(),
         );
         assert!(
@@ -4217,6 +4247,60 @@ mod tests {
                 .any(|note| note.contains("SWS") && note.contains("503")),
             "expected a note with the failure detail, got {:?}",
             plan.notes
+        );
+    }
+
+    #[test]
+    fn whats_new_notes_render_in_the_package_details_pane() {
+        // A package whose deferred version check resolved What's-New notes
+        // gets them appended to its details pane under a localized heading;
+        // packages without notes keep the plain summary + description.
+        let dir = tempdir().unwrap();
+        let localizer = Localizer::embedded(DEFAULT_LOCALE).unwrap();
+        let model = model_from_plan(
+            &localizer,
+            Platform::Windows,
+            Architecture::X64,
+            Vec::new(),
+            None,
+            InstallPlan {
+                target: None,
+                actions: Vec::new(),
+                notes: Vec::new(),
+            },
+        );
+        let target = custom_portable_target_row(&model, dir.path().join("PortableREAPER"), true);
+        let available = vec![AvailablePackage {
+            package_id: PACKAGE_OSARA.to_string(),
+            version: Some(Version::parse("2026.8.1.2278,857265da").unwrap()),
+            whats_new: Some("• Fix the slider.\n• Logging improvements.".to_string()),
+        }];
+        let plan =
+            super::wizard_package_plan_for_target_with_available(&model, Some(&target), &available)
+                .unwrap();
+
+        let osara = plan
+            .package_rows
+            .iter()
+            .find(|row| row.package_id == PACKAGE_OSARA)
+            .expect("OSARA row should be in the package list");
+        assert!(
+            osara.details.contains("What's new in OSARA:"),
+            "expected a localized What's-New heading, got {:?}",
+            osara.details
+        );
+        assert!(osara.details.contains("• Fix the slider."));
+        // The notes follow the description, they don't replace it.
+        assert!(osara.details.contains(&osara.description));
+
+        let reaper = plan
+            .package_rows
+            .iter()
+            .find(|row| row.package_id == PACKAGE_REAPER)
+            .expect("REAPER row should be in the package list");
+        assert!(
+            !reaper.details.contains("What's new"),
+            "a package without resolved notes must keep its plain details"
         );
     }
 

--- a/crates/rabbit-ui-wxdragon/src/wx_app.rs
+++ b/crates/rabbit-ui-wxdragon/src/wx_app.rs
@@ -83,10 +83,11 @@ fn fire_post_install_hook() {
 enum VersionCheckEvent {
     /// "Checking <package>…" — emitted before each fetch starts.
     Checking { package_id: String },
-    /// Per-package outcome: a fetched version, or an error message.
+    /// Per-package outcome: a fetched version plus the package's optional
+    /// What's-New notes, or an error message.
     Result {
         package_id: String,
-        outcome: std::result::Result<String, String>,
+        outcome: std::result::Result<(String, Option<String>), String>,
     },
     /// Worker has finished iterating all packages — the UI should rebuild the
     /// package list with the fetched data and re-enable interaction.
@@ -137,7 +138,7 @@ use crate::{
     wizard_outcome_report_from_success, wizard_package_plan_for_target,
     wizard_package_plan_for_target_with_available,
 };
-use rabbit_core::latest::fetch_latest_for_package;
+use rabbit_core::latest::fetch_latest_details_for_package;
 use rabbit_core::plan::{AvailablePackage, PlanActionKind};
 use rabbit_core::progress::{ProgressEvent, ProgressReporter};
 use std::collections::HashMap;
@@ -2602,17 +2603,20 @@ fn start_version_check(ui: VersionCheckUi) {
             completed += 1;
             ui.widgets.version_check_gauge.set_value(completed);
             match outcome {
-                Ok(version_str) => match rabbit_core::version::Version::parse(&version_str) {
-                    Ok(version) => {
-                        accumulated.push(AvailablePackage {
-                            package_id,
-                            version: Some(version),
-                        });
+                Ok((version_str, whats_new)) => {
+                    match rabbit_core::version::Version::parse(&version_str) {
+                        Ok(version) => {
+                            accumulated.push(AvailablePackage {
+                                package_id,
+                                version: Some(version),
+                                whats_new,
+                            });
+                        }
+                        Err(error) => {
+                            errors.push((package_id, error.to_string()));
+                        }
                     }
-                    Err(error) => {
-                        errors.push((package_id, error.to_string()));
-                    }
-                },
+                }
                 Err(message) => {
                     errors.push((package_id, message));
                 }
@@ -3019,8 +3023,8 @@ fn spawn_version_check_worker(package_ids: Vec<String>) {
                 });
             }));
 
-            let outcome = match fetch_latest_for_package(&package_id) {
-                Ok(version) => Ok(version.to_string()),
+            let outcome = match fetch_latest_details_for_package(&package_id) {
+                Ok(details) => Ok((details.version.to_string(), details.whats_new)),
                 Err(error) => Err(error.to_string()),
             };
 

--- a/locales/de-DE/rabbit.ftl
+++ b/locales/de-DE/rabbit.ftl
@@ -144,6 +144,8 @@ wizard-version-check-error-heading = Fehlgeschlagene Prüfungen
 # $package is the localized package display name; $message is the failure message.
 wizard-version-check-error-line = { $package }: { $message }
 wizard-package-details-label = Paketdetails
+# $package is the localized package display name. Heads the release-notes block in the package details pane.
+wizard-package-whats-new-heading = Neuerungen in { $package }:
 wizard-packages-osara-keymap-heading = OSARA-Tastenzuordnung
 wizard-packages-osara-keymap-replace-label = Aktuelle Tastenzuordnung durch OSARA-Tastenzuordnung ersetzen
 wizard-packages-osara-keymap-unavailable-note = Wählen Sie OSARA aus, um das Verhalten der Tastenzuordnung zu konfigurieren.

--- a/locales/en-US/rabbit.ftl
+++ b/locales/en-US/rabbit.ftl
@@ -144,6 +144,8 @@ wizard-version-check-error-heading = Failed checks
 # $package is the localized package display name; $message is the failure message.
 wizard-version-check-error-line = { $package }: { $message }
 wizard-package-details-label = Package details
+# $package is the localized package display name. Heads the release-notes block in the package details pane.
+wizard-package-whats-new-heading = What's new in { $package }:
 wizard-packages-osara-keymap-heading = OSARA key map
 wizard-packages-osara-keymap-replace-label = Replace your current key map with latest OSARA key map
 wizard-packages-osara-keymap-unavailable-note = Select OSARA to configure its key map behavior.

--- a/locales/fr-FR/rabbit.ftl
+++ b/locales/fr-FR/rabbit.ftl
@@ -144,6 +144,8 @@ wizard-version-check-error-heading = Vérifications échouées
 # $package is the localized package display name; $message is the failure message.
 wizard-version-check-error-line = { $package } : { $message }
 wizard-package-details-label = Détails du paquet
+# $package is the localized package display name. Heads the release-notes block in the package details pane.
+wizard-package-whats-new-heading = Nouveautés dans { $package } :
 wizard-packages-osara-keymap-heading = Raccourcis clavier OSARA
 wizard-packages-osara-keymap-replace-label = Remplacer vos raccourcis clavier par les derniers d'OSARA
 wizard-packages-osara-keymap-unavailable-note = Sélectionnez OSARA pour configurer le comportement de ses raccourcis clavier.

--- a/locales/it-IT/rabbit.ftl
+++ b/locales/it-IT/rabbit.ftl
@@ -144,6 +144,8 @@ wizard-version-check-error-heading = Controlli non riusciti
 # $package is the localized package display name; $message is the failure message.
 wizard-version-check-error-line = { $package }: { $message }
 wizard-package-details-label = Dettagli del pacchetto
+# $package is the localized package display name. Heads the release-notes block in the package details pane.
+wizard-package-whats-new-heading = Novità di { $package }:
 wizard-packages-osara-keymap-heading = Mappa dei tasti OSARA
 wizard-packages-osara-keymap-replace-label = Sostituisci la tua mappa dei tasti attuale con l'ultima mappa dei tasti OSARA
 wizard-packages-osara-keymap-unavailable-note = Seleziona OSARA per configurare il comportamento della sua mappa dei tasti.


### PR DESCRIPTION
Closes #4.

Selecting REAPER, OSARA, SWS or ReaPack on the packages page now appends that package's release notes to the details pane, under a localized "What's new in {package}:" heading — so users (and especially screen-reader users, for whom OSARA's changes were previously only discoverable through GitHub commits) can see what an update brings without leaving the wizard.

## How it works

A new optional `whats_new` block in the embedded package manifests, mirroring the data-driven `version` rules, with three engines in `rabbit-core::latest`:

- **`json_commits`** (OSARA) — reads the `commits` array already present in the `update.json` its version rule fetches: the same feed OSARA's own updater shows. The list is lightly cleaned for listening rather than reading: only each commit's first line is kept, `dev:`-prefixed internal commits are skipped, repeated chore lines ("Update translations.") are collapsed, and trailing issue/PR references (`(#1431)`, `Closes #1424`) are stripped — mid-sentence references are left alone.
- **`text_changelog`** (REAPER, SWS) — cuts the newest section out of a newest-first plain-text changelog (`whatsnew.txt`), located by a `section_start` regex from the manifest (`^v[0-9]` / `^!v`). The fetch is byte-ranged (64 KB head), so REAPER's ~1.4 MB full history is never downloaded; the reader caps the download even against servers that ignore `Range`.
- **`github_release_body`** (ReaPack) — renders the `body` of the same GitHub release its version rule already reads, normalizing Markdown list markers to bullets.

The notes ride alongside the version through the deferred version check (`AvailablePackage.whats_new`) and are composed into the row's `details` in the model layer — so both packages-page implementations (Windows `TreeCtrl` and macOS `DataViewCtrl`) get them with no handler changes, and the whole path is unit-tested without the `gui` feature.

## Deliberate choices (happy to adjust)

- **Best-effort by design**: any notes-side failure (site down, format drift) silently leaves the pane as it is today and never fails the version check. Conversely, a broken first-party `section_start` regex fails loudly at manifest load (`validate_package_spec`).
- **ReaKontrol, Surge XT and app2clap deliberately declare no source**: their rolling tags (`snapshots`, `Nightly`) carry a static boilerplate body ("The latest snapshots of … in its current state of development"), which would be worse than showing nothing.
- **OSARA performs a second GET of the same `update.json`** (one for the version rule, one for the notes). Sharing the fetched body would couple the two resolvers; at ~30 KB per wizard run the simplicity felt like the right trade. Can change if you'd rather cache.
- **Notes content stays in upstream English** under a localized heading (en/de/fr/it — with a test pinning the key's presence in all four locales, since locale parity is otherwise unchecked).
- **OSARA shows the recent-changes window, not a diff against the installed version.** The installed version string embeds its commit hash, so cutting the list at the installed commit (like OSARA's updater does) is a possible follow-up if you think it's worth the extra states (up-to-date → empty list, hash-less detections → fallback).

The REAPER and OSARA panes were exercised on macOS with VoiceOver (fr-FR locale) against the live endpoints; SWS and ReaPack go through the same engines, validated with fixture tests and probes of their live feeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
