### PR TITLE
fix(ui): make Cmd+Q quit RABBIT on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ from this file and posts it as the GitHub release body.
 
 ### Fixed
 
+- macOS: Cmd+Q (and the application menu's Quit item) now quits RABBIT.
+  The wizard installed no menu bar at all, so macOS had no functional
+  Quit item to offer and Cmd+Q was a dead key. RABBIT now installs a
+  minimal menu bar on macOS whose stock Quit item lands in the
+  application menu as usual; quitting this way behaves exactly like the
+  window's close button.
 - macOS: RABBIT no longer refuses to launch after a self-update. Updating
   replaces the binary inside `RABBIT.app` and re-signs the bundle with a
   local (ad-hoc) signature — but the bundle still carried the quarantine

--- a/crates/rabbit-ui-wxdragon/src/wx_app.rs
+++ b/crates/rabbit-ui-wxdragon/src/wx_app.rs
@@ -2075,6 +2075,39 @@ pub fn run() {
             frame_for_close.close(true);
         });
 
+        // Handle the application-menu Quit item: the macOS menu bar
+        // installed below carries a stock wxID_EXIT item, which wxOSX
+        // relocates into the application menu as "Quit rabbit" (Cmd+Q).
+        // Selecting it emits a plain menu command with that id at the
+        // frame — route it to the same teardown as the wizard's Close
+        // button and the window close box. Bound on every platform, but
+        // only macOS installs a menu that can emit it.
+        {
+            let frame_for_quit = frame.clone();
+            frame.on_menu_selected(move |event| {
+                if event.get_id() == wxdragon::id::ID_EXIT {
+                    frame_for_quit.close(true);
+                }
+            });
+        }
+
+        // Without any menu bar, wxOSX installs no functional main menu at
+        // all: the wizard's application menu had a dead Quit item and Cmd+Q
+        // did nothing. Installing a minimal menu bar makes wxWidgets build
+        // a real application menu and wire its Quit item to the stock
+        // wxID_EXIT command handled above. `Ctrl+Q` in a wx accelerator
+        // string means Cmd+Q on macOS. macOS-only: on Windows this would
+        // add a visible File menu to a wizard that doesn't want one, and
+        // Alt+F4 already closes the window natively there.
+        #[cfg(target_os = "macos")]
+        {
+            let file_menu = Menu::builder()
+                .append_item(wxdragon::id::ID_EXIT, "E&xit\tCtrl+Q", "")
+                .build();
+            let menu_bar = MenuBar::builder().append(file_menu, "&File").build();
+            frame.set_menu_bar(menu_bar);
+        }
+
         {
             let model = Arc::clone(&model);
             let widgets = wizard_widgets;
@@ -2491,8 +2524,7 @@ fn build_language_footer(root_panel: &Panel, root: &BoxSizer, model: &WizardMode
     let current_locale = model.current_language.clone();
 
     // The popup menu dispatches its EVT_MENU to the popup's owner window
-    // (the footer Panel here), not to the button — only Panel/ScrolledWindow
-    // implement MenuEvents in wxdragon today.
+    // (the footer Panel here), not to the button that opened it.
     {
         let language_options = language_options.clone();
         let current_locale = current_locale.clone();


### PR DESCRIPTION
On macOS, Cmd+Q (and the application menu's Quit item) did nothing: the wizard installs no menu bar, so wxOSX never built a functional main menu and there was no working Quit item at all.

The fix installs a minimal menu bar on macOS with a stock `wxID_EXIT` item. wxOSX relocates that item into the application menu as the standard "Quit rabbit" (Cmd+Q), and selecting it emits a `wxID_EXIT` menu command at the frame, which a new `on_menu_selected` handler routes to the same teardown as the wizard's Close button and the window close box.

Notes:

- The `wxID_EXIT` handler is bound on every platform — it is inert where no menu can emit the id — but the menu bar itself is macOS-only, so the Windows wizard keeps its menu-less window and native Alt+F4 behavior.
- Quitting via Cmd+Q behaves exactly like clicking the window's close box, which is already possible at any wizard step; no new state is reachable.
- wxOSX's menu adaptation may leave the donor "File" menu behind after relocating the Quit item; if it does and it bothers screen-reader menu navigation, it can be addressed in a follow-up (verified working with VoiceOver as-is).
- Also drops an outdated comment claiming only Panel/ScrolledWindow implement `MenuEvents` in wxdragon — `Frame` has implemented it since before the version RABBIT pins.

Tested on macOS (aarch64, VoiceOver): Cmd+Q now quits the wizard immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
