### PR TITLE
ci: lint the gui-gated UI layer with clippy in the verify job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,32 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets
 
+      # The gui feature gates all of wx_app.rs, so the workspace-level
+      # clippy above never lints it — the artifacts job compiles it, but
+      # only late in the workflow and without lints. The GUI build needs
+      # LLVM/ninja for wxdragon's C++ layer (same setup as the artifacts
+      # job); Swatinem/rust-cache keeps the wxWidgets build cached between
+      # runs, so only cache-miss runs pay the full C++ compile.
+      - name: Install GUI build prerequisites (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          choco install llvm ninja --yes --no-progress
+          "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "C:\ProgramData\chocolatey\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Install GUI build prerequisites (macOS)
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          brew install llvm ninja
+          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+          echo "LIBCLANG_PATH=$(brew --prefix llvm)/lib" >> "$GITHUB_ENV"
+
+      - name: Clippy (GUI feature)
+        run: cargo clippy -p rabbit-ui-wxdragon --features gui --all-targets
+
       - name: Test workspace
         run: cargo test --workspace
 


### PR DESCRIPTION
The `verify` job runs fmt, clippy and tests without the `gui` feature, so `wx_app.rs` — the entire wxdragon UI layer, including each platform's cfg-gated packages-page branch — was never linted: only the `artifacts` job compiled it, late in the workflow and without lints.

This adds a `cargo clippy -p rabbit-ui-wxdragon --features gui --all-targets` pass to both verify runners, so GUI-side compile errors and lints surface early on both platforms. (Clippy only lints the selected package, hence `-p rabbit-ui-wxdragon` rather than `-p rabbit`, which would compile the crate but not lint it.)

Notes:

- Needs the same LLVM/ninja prerequisites as the artifacts job for wxdragon's C++ layer — the steps are copied from there. `Swatinem/rust-cache` caches the wxWidgets build between runs, so only cache-miss runs pay the full C++ compile (the run on this PR, uncached, kept verify well under the artifacts job's own duration).
- The gui-gated unit tests still don't run anywhere (they need a GUI runtime); this only closes the lint/compile gap.
- The pass comes out clean on current `main` — no existing lints, so nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)