### PR TITLE
feat(ui): show a progress window while RABBIT updates itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,27 @@ from this file and posts it as the GitHub release body.
 
 ## [Unreleased]
 
+### Added
+
+- The "RABBIT update available" prompt now answers "what would I be
+  updating to?" before you decide: alongside the question it shows the
+  release notes for the update, in a read-only box you can read through
+  and scroll like the package details pane. The notes cover every release
+  published since the version you are running, not just the newest one, so
+  skipping a couple of updates still tells the whole story. Update now is
+  the default button, so Enter accepts from anywhere in the dialog and
+  Escape declines. When the notes can't be fetched — no network, GitHub
+  down — the prompt falls back to the short question it has always asked,
+  since nothing about the notes should stand between you and an update.
+  `rabbit self-update check` prints the same notes. Release notes are also
+  stripped of their Markdown wherever they are shown, RABBIT's own and
+  ReaPack's alike — headings, bold, inline code and links now read as the
+  words they contain rather than as strings of asterisks, hashes and
+  backticks spoken out loud. Underscores are left alone, since in these
+  notes they are far more often part of a name you need to hear exactly
+  (`depends_on`) than emphasis, and a link's address is dropped while the
+  text you would have clicked is kept.
+
 ### Fixed
 
 - macOS: the app bundle now declares Spanish, so VoiceOver reads RABBIT's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ from this file and posts it as the GitHub release body.
 
 ### Added
 
+- Accepting a RABBIT update now opens a progress window instead of leaving
+  you watching a status line: it names the phase ("Downloading RABBIT…
+  4.1 MB of 10.2 MB"), fills a progress bar as the bytes arrive, and keeps
+  a running log of each step as it completes, so a screen reader can be
+  walked back through what happened. The bar covers the download, the
+  checksum verification and the install, and the window closes on its own
+  when RABBIT relaunches into the new version. It has no Cancel button on
+  purpose — once the file swap starts there is nothing to safely undo — and
+  it can't be dismissed by mistake with Escape.
+
 - The "RABBIT update available" prompt now answers "what would I be
   updating to?" before you decide: alongside the question it shows the
   release notes for the update, in a read-only box you can read through

--- a/crates/rabbit-cli/src/lib.rs
+++ b/crates/rabbit-cli/src/lib.rs
@@ -842,6 +842,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
                     &ApplySelfUpdateOptions {
                         install_root,
                         install_target_basename: None,
+                        ..Default::default()
                     },
                 )?;
                 if json {

--- a/crates/rabbit-cli/src/lib.rs
+++ b/crates/rabbit-cli/src/lib.rs
@@ -30,7 +30,8 @@ use rabbit_core::rollback::{
 use rabbit_core::self_update::{
     ApplySelfUpdateOptions, DEFAULT_SELF_UPDATE_MANIFEST_URL, SelfUpdateApplyReport,
     SelfUpdateCheckReport, SelfUpdateStageReport, apply_self_update, check_self_update,
-    default_self_update_staging_dir, relaunch_current_executable, stage_self_update,
+    default_self_update_staging_dir, relaunch_current_executable,
+    resolve_self_update_release_notes, stage_self_update,
 };
 use rabbit_core::setup::{SetupOptions, SetupReport, execute_setup_operation};
 use serde::Serialize;
@@ -803,6 +804,11 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
                     println!("{}", serde_json::to_string_pretty(&report)?);
                 } else {
                     print_self_update_report(&report);
+                    // Only the check command pays for the notes fetch: stage
+                    // and apply print the same report, and neither should
+                    // spend a round-trip on text nobody asked to read while
+                    // an update is being installed.
+                    print_self_update_release_notes(&report);
                 }
             }
             SelfUpdateCommand::Stage {
@@ -1606,6 +1612,19 @@ fn print_self_update_report(report: &SelfUpdateCheckReport) {
     println!("Asset platform: {:?}", report.asset.platform);
     println!("Asset URL: {}", report.asset.url);
     println!("Asset SHA-256: {}", report.asset.sha256);
+}
+
+/// Print what the pending update actually changes, covering every release
+/// between the running version and the latest. Silent when there is no
+/// update, or when the notes can't be fetched — the check itself has already
+/// reported everything that matters.
+fn print_self_update_release_notes(report: &SelfUpdateCheckReport) {
+    let Some(notes) = resolve_self_update_release_notes(report) else {
+        return;
+    };
+    println!();
+    println!("What's new since {}:", report.current_version);
+    println!("{notes}");
 }
 
 fn print_self_update_stage_report(report: &SelfUpdateStageReport) {

--- a/crates/rabbit-core/src/latest.rs
+++ b/crates/rabbit-core/src/latest.rs
@@ -353,20 +353,93 @@ fn render_release_section(release: &Value) -> Option<String> {
     }
 }
 
-/// The maintainer-written release body with Markdown list markers rendered
-/// as bullets, other lines verbatim, surrounding whitespace trimmed.
+/// The maintainer-written release body as plain text: list markers become
+/// bullets, every other piece of Markdown syntax is removed, and surrounding
+/// whitespace is trimmed.
+///
+/// Release bodies are written to be *read* on a web page, where the syntax
+/// disappears into bold text and links. Here they are *listened to*, and
+/// every marker survives as spoken punctuation — "asterisk asterisk REAPER
+/// language packs asterisk asterisk". So the markers go and the words stay.
 fn render_release_body_lines(notes: &str) -> String {
     let lines: Vec<String> = notes
         .lines()
         .map(|line| {
-            let line = line.trim_end();
+            let line = strip_markdown_markup(line.trim_end());
             match line.strip_prefix("- ").or_else(|| line.strip_prefix("* ")) {
                 Some(item) => format!("• {item}"),
-                None => line.to_string(),
+                None => line,
             }
         })
         .collect();
     lines.join("\n").trim().to_string()
+}
+
+/// One line of Markdown reduced to the text it renders as: heading markers,
+/// emphasis, inline code and link syntax are removed, and what the reader
+/// would have seen is kept.
+///
+/// Deliberately *not* handled: underscores, which mean emphasis in Markdown
+/// but appear far more often in these notes as parts of identifiers
+/// (`whats_new`, `depends_on`) — stripping those would corrupt the very
+/// names a listener needs to hear exactly. Bare URLs are left intact too:
+/// unlike a link's target, a URL written out on its own is content.
+pub(crate) fn strip_markdown_markup(line: &str) -> String {
+    // Headings first, on the raw line: `#` only opens a heading at the very
+    // start, so this can't be a general replacement. A line of nothing but
+    // hashes is a horizontal rule and collapses to nothing.
+    let without_headings = line.trim_start_matches('#');
+    let line = if without_headings.len() == line.len() {
+        line
+    } else {
+        without_headings.trim_start()
+    };
+    let line = markdown_link_regex().replace_all(line, "$text");
+    let line = markdown_code_regex().replace_all(&line, "$code");
+    let line = markdown_bold_regex().replace_all(&line, "$text");
+    markdown_italic_regex().replace_all(&line, "$text").into()
+}
+
+/// An inline link or image — `[ReaPack](https://reapack.com)`,
+/// `![shot](img.png)` — reduced to its visible text. The target is a place
+/// to click, which a spoken list of changes has no use for.
+fn markdown_link_regex() -> &'static Regex {
+    static MARKDOWN_LINK: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    MARKDOWN_LINK.get_or_init(|| {
+        Regex::new(r"!?\[(?<text>[^\]]*)\]\([^)]*\)").expect("static markdown link regex is valid")
+    })
+}
+
+/// Inline code spans, whatever the backtick run length. The content is kept
+/// verbatim: it is usually a path, flag or identifier the listener needs
+/// exactly as written — only the backticks around it go.
+fn markdown_code_regex() -> &'static Regex {
+    static MARKDOWN_CODE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    MARKDOWN_CODE.get_or_init(|| {
+        Regex::new(r"`+(?<code>[^`]+)`+").expect("static markdown code regex is valid")
+    })
+}
+
+/// Bold, `**like this**`. Run before the italic pass so the doubled markers
+/// are gone before single ones are considered.
+fn markdown_bold_regex() -> &'static Regex {
+    static MARKDOWN_BOLD: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    MARKDOWN_BOLD.get_or_init(|| {
+        Regex::new(r"\*\*(?<text>[^*]+)\*\*").expect("static markdown bold regex is valid")
+    })
+}
+
+/// Italic, `*like this*`. Markdown's own rule applies at both ends — no
+/// space just inside either marker — and it is what keeps stray asterisks
+/// from pairing up: in `Renders *.wav files 2 * 3 times faster` the closing
+/// candidate is preceded by a space, so nothing matches and the line
+/// survives intact.
+fn markdown_italic_regex() -> &'static Regex {
+    static MARKDOWN_ITALIC: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    MARKDOWN_ITALIC.get_or_init(|| {
+        Regex::new(r"\*(?<text>[^*\s](?:[^*]*[^*\s])?)\*")
+            .expect("static markdown italic regex is valid")
+    })
 }
 
 /// The version a release advertises via its `tag_name` (`v1.2.6`). `None`
@@ -884,7 +957,7 @@ pub(crate) fn jaws_for_reaper_version_from_filename(name: &str) -> Option<Versio
     last.and_then(|candidate| Version::parse(candidate).ok())
 }
 
-fn build_http_client() -> Result<Client> {
+pub(crate) fn build_http_client() -> Result<Client> {
     Client::builder()
         .user_agent(USER_AGENT)
         .build()
@@ -894,7 +967,7 @@ fn build_http_client() -> Result<Client> {
         })
 }
 
-fn http_get_text(client: &Client, url: &str) -> Result<String> {
+pub(crate) fn http_get_text(client: &Client, url: &str) -> Result<String> {
     let request = crate::http::maybe_apply_github_auth(client.get(url), url);
     let response = request
         .send()
@@ -1329,6 +1402,51 @@ mod tests {
         assert_eq!(no_body.unwrap(), "v1");
         let blank = super::resolve_github_release_bodies(r#"{"body":"  \r\n "}"#, url, None);
         assert!(blank.is_err());
+    }
+
+    #[test]
+    fn strips_markdown_markup_from_a_release_body() {
+        // RABBIT's own release bodies are whole Keep a Changelog sections:
+        // headings, bold, inline code and links throughout. Every marker
+        // that survives is punctuation spoken out loud, so none of them do.
+        let url = "https://api.github.com/repos/Timtam/rabbit/releases?per_page=20";
+        // The body's opening quote stays on the line above: a `r#"` literal
+        // whose content started with `"#` would close on the spot.
+        let body = concat!(
+            r#"{"tag_name":"v0.4.0","body":""#,
+            r#"### Added\r\n\r\n- Install **REAPER language packs**\r\n"#,
+            r#"- Read [the manual](https://reapack.com/) about `--package-variant`\r\n"#,
+            r#"\r\n###\r\nThe *whats_new* block. C# is a note name.""#,
+            "}"
+        );
+        let notes = super::resolve_github_release_bodies(body, url, None).unwrap();
+        assert_eq!(
+            notes,
+            concat!(
+                "v0.4.0\nAdded\n\n• Install REAPER language packs\n",
+                "• Read the manual about --package-variant\n",
+                // Two blank lines: the one the author wrote, plus the
+                // horizontal rule that collapsed into another.
+                "\n\nThe whats_new block. C# is a note name."
+            )
+        );
+    }
+
+    #[test]
+    fn markdown_stripping_leaves_prose_and_identifiers_alone() {
+        // The strip runs over every line of every release body, so what it
+        // must NOT touch matters as much as what it removes: underscores
+        // read as emphasis in Markdown but are identifier characters here,
+        // a lone asterisk is a glob or a footnote mark, and a bare URL is
+        // content rather than a link's hidden target.
+        for line in [
+            "Set depends_on in the manifest",
+            "Renders *.wav files 2 * 3 times faster",
+            "See https://reapack.com/donate for details",
+            "Plain prose, nothing to strip.",
+        ] {
+            assert_eq!(super::strip_markdown_markup(line), line);
+        }
     }
 
     #[test]

--- a/crates/rabbit-core/src/localization.rs
+++ b/crates/rabbit-core/src/localization.rs
@@ -447,6 +447,31 @@ mod tests {
     }
 
     #[test]
+    fn self_update_notes_heading_formats_in_every_embedded_locale() {
+        // Same exposure as the package heading below: composed with
+        // .format() without a missing-key fallback, and it doubles as the
+        // accessible name of the notes box in the update prompt — a locale
+        // that forgot the key would have the screen reader announce the raw
+        // key id at the exact moment the user is deciding whether to update.
+        for &locale in embedded_locales() {
+            let localizer = Localizer::embedded(locale).unwrap();
+            let message = localizer.format(
+                "wizard-self-update-prompt-notes-heading",
+                &[("current", "0.3.2")],
+            );
+            assert!(
+                !message.missing,
+                "locale {locale} is missing wizard-self-update-prompt-notes-heading"
+            );
+            assert!(
+                message.value.contains("0.3.2"),
+                "locale {locale} should interpolate the running version, got {:?}",
+                message.value
+            );
+        }
+    }
+
+    #[test]
     fn whats_new_heading_formats_in_every_embedded_locale() {
         // The heading is composed with .format() at row-build time without a
         // missing-key fallback, so a locale that forgets the key would show

--- a/crates/rabbit-core/src/self_update.rs
+++ b/crates/rabbit-core/src/self_update.rs
@@ -24,6 +24,19 @@ const USER_AGENT: &str = concat!(
 pub const DEFAULT_SELF_UPDATE_MANIFEST_URL: &str =
     "https://github.com/Timtam/rabbit/releases/latest/download/rabbit-update-stable.json";
 
+/// GitHub's release listing for RABBIT itself — the What's-New source behind
+/// the notes shown next to an available self-update. It is the same endpoint
+/// shape ReaPack's `whats_new` rule reads, so
+/// [`crate::latest::resolve_github_release_bodies`] renders both the same
+/// way: one heading line per release, then the body the maintainer wrote.
+/// `per_page` is capped well above the ten sections the renderer stops at,
+/// so asking for more would only cost bandwidth. Deliberately separate from
+/// [`DEFAULT_SELF_UPDATE_MANIFEST_URL`]: the manifest is a release asset
+/// carrying download URLs and checksums, while the notes come from the
+/// release metadata GitHub keeps for every published tag.
+pub const DEFAULT_SELF_UPDATE_RELEASE_NOTES_URL: &str =
+    "https://api.github.com/repos/Timtam/rabbit/releases?per_page=20";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SelfUpdateManifest {
     pub version: Version,
@@ -303,6 +316,43 @@ pub fn check_self_update(platform: Platform, manifest_url: &str) -> Result<SelfU
         current_rabbit_version()?,
         &manifest,
     )
+}
+
+/// The release notes covering every RABBIT release above `installed`, newest
+/// first, rendered the same way the packages page renders a package's
+/// What's-New notes. Someone who skipped two releases reads all three sets of
+/// notes rather than only the newest, which is the whole point of showing
+/// them at the update prompt: the answer to "what do I get if I say yes?"
+/// spans everything they missed, not just the last tag.
+///
+/// The section cap and the draft/prerelease skip live in
+/// [`crate::latest::resolve_github_release_bodies`]; RABBIT knows its own
+/// installed version exactly (it is compiled in), so the trim is precise
+/// here in a way it can never be for a third-party package detected on disk.
+pub fn fetch_self_update_release_notes(notes_url: &str, installed: &Version) -> Result<String> {
+    let client = crate::latest::build_http_client()?;
+    let body = crate::latest::http_get_text(&client, notes_url)?;
+    crate::latest::resolve_github_release_bodies(&body, notes_url, Some(installed))
+}
+
+/// Best-effort [`fetch_self_update_release_notes`] for a completed check.
+/// `None` when there is nothing to update to, or when the notes can't be
+/// fetched or rendered.
+///
+/// Notes are decoration around the update prompt, never a precondition for
+/// it: a GitHub outage, an API rate limit, or a release published without a
+/// body must not keep the user from updating, so every failure degrades to
+/// the plain prompt instead of surfacing an error. This mirrors how the
+/// packages page treats a package's What's-New source.
+pub fn resolve_self_update_release_notes(report: &SelfUpdateCheckReport) -> Option<String> {
+    if !report.update_available {
+        return None;
+    }
+    fetch_self_update_release_notes(
+        DEFAULT_SELF_UPDATE_RELEASE_NOTES_URL,
+        &report.current_version,
+    )
+    .ok()
 }
 
 pub fn stage_self_update(
@@ -1505,12 +1555,13 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        ApplySelfUpdateOptions, SelfUpdateAssetKind, SelfUpdateAssetSelection,
-        SelfUpdateCheckReport, SelfUpdateManifest, SelfUpdateStageReport, apply_self_update,
-        arch_token_from_asset_url, current_rabbit_version, enclosing_app_bundle,
+        ApplySelfUpdateOptions, DEFAULT_SELF_UPDATE_RELEASE_NOTES_URL, SelfUpdateAssetKind,
+        SelfUpdateAssetSelection, SelfUpdateCheckReport, SelfUpdateManifest, SelfUpdateStageReport,
+        apply_self_update, arch_token_from_asset_url, current_rabbit_version, enclosing_app_bundle,
         evaluate_self_update_report, extracted_main_binary, locate_extracted_app,
-        parse_self_update_manifest, select_asset_for_platform_with_context,
-        stage_self_update_from_report, swap_bundle_directories, sweep_stale_update_scratch_dirs,
+        parse_self_update_manifest, resolve_self_update_release_notes,
+        select_asset_for_platform_with_context, stage_self_update_from_report,
+        swap_bundle_directories, sweep_stale_update_scratch_dirs,
     };
     use crate::RabbitError;
     use crate::hash::sha256_file;
@@ -1838,6 +1889,38 @@ mod tests {
 
         assert!(report.update_available);
         assert!(report.requires_manual_transition);
+    }
+
+    #[test]
+    fn release_notes_are_skipped_when_no_update_is_available() {
+        // The `update_available` guard is what keeps an up-to-date RABBIT
+        // from spending a GitHub API request on notes nobody will see — and
+        // it is what keeps this test offline, since returning early is the
+        // only path through `resolve_self_update_release_notes` that never
+        // reaches the network.
+        let manifest = sample_manifest();
+        let report = evaluate_self_update_report(
+            Platform::Windows,
+            Architecture::X64,
+            MANIFEST_URL,
+            manifest.version.clone(),
+            &manifest,
+        )
+        .unwrap();
+
+        assert!(!report.update_available);
+        assert_eq!(resolve_self_update_release_notes(&report), None);
+    }
+
+    #[test]
+    fn release_notes_url_points_at_the_github_release_listing() {
+        // A single-release endpoint (`/releases/latest`) would silently
+        // reduce the notes to the newest version only, defeating the whole
+        // point of spanning everything the user skipped. The renderer
+        // accepts either shape, so nothing else would catch the mistake.
+        assert!(DEFAULT_SELF_UPDATE_RELEASE_NOTES_URL.starts_with("https://api.github.com/"));
+        assert!(DEFAULT_SELF_UPDATE_RELEASE_NOTES_URL.contains("/repos/Timtam/rabbit/releases"));
+        assert!(!DEFAULT_SELF_UPDATE_RELEASE_NOTES_URL.contains("/releases/latest"));
     }
 
     #[test]

--- a/crates/rabbit-core/src/self_update.rs
+++ b/crates/rabbit-core/src/self_update.rs
@@ -10,6 +10,7 @@ use crate::Result;
 use crate::error::{IoPathContext, RabbitError};
 use crate::hash::sha256_file;
 use crate::model::{Architecture, Platform};
+use crate::progress::{ProgressEvent, ProgressReporter};
 use crate::signature::{SignatureVerdict, verify_executable_signature};
 use crate::version::Version;
 
@@ -143,6 +144,11 @@ pub struct ApplySelfUpdateOptions {
     /// install target — RABBIT swaps in place under the user's existing
     /// filename regardless of what the download was called.
     pub install_target_basename: Option<String>,
+    /// Where to send the apply phase's progress events. `None` — the
+    /// default — reports nothing, which is what the CLI and the tests want.
+    /// A GUI passes a reporter so its progress dialog can say "Installing"
+    /// once the download is done and close itself when the swap lands.
+    pub progress: Option<ProgressReporter>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -355,13 +361,41 @@ pub fn resolve_self_update_release_notes(report: &SelfUpdateCheckReport) -> Opti
     .ok()
 }
 
+/// Progress identity for RABBIT's own update, standing where a package id
+/// stands for an install. RABBIT is not a package — it is never in the
+/// manifest and never in an install plan — but the download engine and the
+/// UI both speak [`ProgressEvent`], so borrowing the slot lets the update
+/// reuse that pipeline whole rather than growing a parallel one.
+pub const SELF_UPDATE_PROGRESS_ID: &str = "rabbit-self-update";
+
 pub fn stage_self_update(
     platform: Platform,
     manifest_url: &str,
     staging_dir: &Path,
 ) -> Result<SelfUpdateStageReport> {
+    stage_self_update_with_progress(
+        platform,
+        manifest_url,
+        staging_dir,
+        &ProgressReporter::noop(),
+    )
+}
+
+/// [`stage_self_update`] reporting download progress as it goes.
+///
+/// The events are the ones the install pipeline emits — `DownloadStarted`,
+/// `DownloadProgress`, `DownloadCompleted` — all carrying
+/// [`SELF_UPDATE_PROGRESS_ID`], and they arrive on the calling thread. A UI
+/// that wants to show a progress bar therefore forwards them to its own
+/// thread exactly as it does for a package install.
+pub fn stage_self_update_with_progress(
+    platform: Platform,
+    manifest_url: &str,
+    staging_dir: &Path,
+    progress: &ProgressReporter,
+) -> Result<SelfUpdateStageReport> {
     let report = check_self_update(platform, manifest_url)?;
-    stage_self_update_from_report(&report, staging_dir)
+    stage_self_update_from_report_with_progress(&report, staging_dir, progress)
 }
 
 pub fn relaunch_current_executable() -> Result<u32> {
@@ -436,6 +470,16 @@ pub fn apply_self_update(
             Some(root) => root,
             None => PathBuf::new(),
         });
+
+    // Everything above is verification; from here on files move. The
+    // install phase is a single opaque step to a progress bar — a bundle
+    // swap has no meaningful sub-steps to count — so it is bracketed as one
+    // started/completed pair.
+    if let Some(progress) = options.progress.as_ref() {
+        progress.report(ProgressEvent::InstallStarted {
+            package_id: SELF_UPDATE_PROGRESS_ID.to_string(),
+        });
+    }
 
     let mut replaced = Vec::new();
     let mut skipped = Vec::new();
@@ -515,6 +559,14 @@ pub fn apply_self_update(
             ROLLBACK_SUFFIX
         )
     };
+
+    // Only on the success path: an error return short-circuits without a
+    // completion event, matching how the install pipeline treats failures.
+    if let Some(progress) = options.progress.as_ref() {
+        progress.report(ProgressEvent::InstallCompleted {
+            package_id: SELF_UPDATE_PROGRESS_ID.to_string(),
+        });
+    }
 
     Ok(SelfUpdateApplyReport {
         stage: stage.clone(),
@@ -1150,9 +1202,19 @@ fn evaluate_self_update_report(
     })
 }
 
+/// Staging without progress, kept as the shape every existing caller and
+/// test already uses.
 fn stage_self_update_from_report(
     report: &SelfUpdateCheckReport,
     staging_dir: &Path,
+) -> Result<SelfUpdateStageReport> {
+    stage_self_update_from_report_with_progress(report, staging_dir, &ProgressReporter::noop())
+}
+
+fn stage_self_update_from_report_with_progress(
+    report: &SelfUpdateCheckReport,
+    staging_dir: &Path,
+    progress: &ProgressReporter,
 ) -> Result<SelfUpdateStageReport> {
     if !report.update_available {
         return Ok(SelfUpdateStageReport {
@@ -1190,6 +1252,16 @@ fn stage_self_update_from_report(
     if target_path.is_file() {
         let existing_sha256 = sha256_file(&target_path)?;
         if existing_sha256 == report.asset.sha256 {
+            // Already staged by an earlier run: report the pair anyway so a
+            // UI sees a download phase open and close instead of jumping
+            // straight to installing with an empty bar behind it.
+            progress.report(ProgressEvent::DownloadStarted {
+                package_id: SELF_UPDATE_PROGRESS_ID.to_string(),
+                bytes_total: None,
+            });
+            progress.report(ProgressEvent::DownloadCompleted {
+                package_id: SELF_UPDATE_PROGRESS_ID.to_string(),
+            });
             return Ok(SelfUpdateStageReport {
                 check: report.clone(),
                 staging_dir: staging_dir.to_path_buf(),
@@ -1212,7 +1284,12 @@ fn stage_self_update_from_report(
         &report.asset.url,
         local_source_path.as_deref(),
         &target_path,
+        progress,
     )?;
+    // The checksum runs over ~10 MB and is not instant on a slow disk, so
+    // the download is only reported complete once the file is known good —
+    // a UI that hides its progress bar on `DownloadCompleted` would
+    // otherwise sit blank through the verification.
     let verified_sha256 = sha256_file(&target_path)?;
     if verified_sha256 != report.asset.sha256 {
         let _ = fs::remove_file(&target_path);
@@ -1222,6 +1299,10 @@ fn stage_self_update_from_report(
             actual: verified_sha256,
         });
     }
+
+    progress.report(ProgressEvent::DownloadCompleted {
+        package_id: SELF_UPDATE_PROGRESS_ID.to_string(),
+    });
 
     Ok(SelfUpdateStageReport {
         check: report.clone(),
@@ -1422,6 +1503,7 @@ fn download_self_update_asset(
     url: &str,
     local_source_path: Option<&Path>,
     target_path: &Path,
+    progress: &ProgressReporter,
 ) -> Result<()> {
     let part_path = target_path.with_extension(format!(
         "{}.part",
@@ -1432,6 +1514,14 @@ fn download_self_update_asset(
     ));
 
     if let Some(source_path) = local_source_path {
+        // A local file (test fixture, file:// manifest) has no byte
+        // progress to report, but the started/completed pair still has to
+        // bracket it: a UI that only shows its progress bar between the two
+        // would otherwise never show one at all.
+        progress.report(ProgressEvent::DownloadStarted {
+            package_id: SELF_UPDATE_PROGRESS_ID.to_string(),
+            bytes_total: None,
+        });
         fs::copy(source_path, &part_path).with_path(source_path)?;
         fs::rename(&part_path, target_path).with_path(target_path)?;
         return Ok(());
@@ -1442,13 +1532,10 @@ fn download_self_update_asset(
     // retry with resume, and network failures classified as download
     // interruptions instead of I/O errors at the .part path. (The staged
     // file's sha256 is verified against the manifest afterwards, so a
-    // resumed download can never swap in a mismatched binary.)
-    crate::artifact::download_url_with_retries(
-        url,
-        &part_path,
-        "rabbit-self-update",
-        &crate::progress::ProgressReporter::noop(),
-    )?;
+    // resumed download can never swap in a mismatched binary.) It emits
+    // `DownloadStarted` and the byte-progress ticks; the completion event
+    // is ours to send once the checksum has been verified.
+    crate::artifact::download_url_with_retries(url, &part_path, SELF_UPDATE_PROGRESS_ID, progress)?;
 
     fs::rename(&part_path, target_path).with_path(target_path)?;
     Ok(())
@@ -2309,6 +2396,7 @@ mod tests {
             &ApplySelfUpdateOptions {
                 install_root: Some(install_root.path().to_path_buf()),
                 install_target_basename: Some("RABBIT.exe".to_string()),
+                ..Default::default()
             },
         )
         .unwrap();
@@ -2344,6 +2432,7 @@ mod tests {
             &ApplySelfUpdateOptions {
                 install_root: Some(install_root.path().to_path_buf()),
                 install_target_basename: Some("RABBIT".to_string()),
+                ..Default::default()
             },
         )
         .unwrap();
@@ -2380,6 +2469,7 @@ mod tests {
             &ApplySelfUpdateOptions {
                 install_root: Some(install_root.path().to_path_buf()),
                 install_target_basename: Some("RABBIT.exe".to_string()),
+                ..Default::default()
             },
         )
         .unwrap_err();
@@ -2418,6 +2508,7 @@ mod tests {
             &ApplySelfUpdateOptions {
                 install_root: Some(install_root.path().to_path_buf()),
                 install_target_basename: Some("RABBIT.exe".to_string()),
+                ..Default::default()
             },
         )
         .unwrap_err();
@@ -2460,6 +2551,7 @@ mod tests {
             &ApplySelfUpdateOptions {
                 install_root: Some(install_root.path().to_path_buf()),
                 install_target_basename: Some("rabbit".to_string()),
+                ..Default::default()
             },
         )
         .unwrap();

--- a/crates/rabbit-ui-wxdragon/src/lib.rs
+++ b/crates/rabbit-ui-wxdragon/src/lib.rs
@@ -42,7 +42,8 @@ use rabbit_core::resource::{
 use rabbit_core::self_update::{
     ApplySelfUpdateOptions, DEFAULT_SELF_UPDATE_MANIFEST_URL, SelfUpdateApplyReport,
     SelfUpdateCheckReport, apply_self_update, check_self_update, default_self_update_staging_dir,
-    relaunch_current_executable, resolve_self_update_release_notes, stage_self_update,
+    relaunch_current_executable, resolve_self_update_release_notes,
+    stage_self_update_with_progress,
 };
 use rabbit_core::setup::{SetupOptions, SetupReport, setup_requires_extension_support};
 use rabbit_core::version::Version;
@@ -1826,15 +1827,32 @@ pub fn run_wizard_self_update_release_notes(report: &SelfUpdateCheckReport) -> O
     resolve_self_update_release_notes(report)
 }
 
-pub fn run_wizard_self_update_apply() -> Result<SelfUpdateApplyReport> {
+/// Download-then-install for RABBIT itself, reporting both phases through
+/// `progress`.
+///
+/// Runs on a worker thread, so `progress` is invoked off the UI thread and
+/// the caller is responsible for forwarding events onto it — the same
+/// contract the package install pipeline has. Pass
+/// `ProgressReporter::noop()` to run it silently.
+///
+/// [`ProgressReporter`]: rabbit_core::progress::ProgressReporter
+pub fn run_wizard_self_update_apply(
+    progress: &rabbit_core::progress::ProgressReporter,
+) -> Result<SelfUpdateApplyReport> {
     let platform = Platform::current().ok_or(RabbitError::UnsupportedPlatform)?;
     let staging_dir = default_self_update_staging_dir();
-    let stage = stage_self_update(platform, DEFAULT_SELF_UPDATE_MANIFEST_URL, &staging_dir)?;
+    let stage = stage_self_update_with_progress(
+        platform,
+        DEFAULT_SELF_UPDATE_MANIFEST_URL,
+        &staging_dir,
+        progress,
+    )?;
     apply_self_update(
         &stage,
         &ApplySelfUpdateOptions {
             install_root: None,
             install_target_basename: None,
+            progress: Some(progress.clone()),
         },
     )
 }

--- a/crates/rabbit-ui-wxdragon/src/lib.rs
+++ b/crates/rabbit-ui-wxdragon/src/lib.rs
@@ -42,7 +42,7 @@ use rabbit_core::resource::{
 use rabbit_core::self_update::{
     ApplySelfUpdateOptions, DEFAULT_SELF_UPDATE_MANIFEST_URL, SelfUpdateApplyReport,
     SelfUpdateCheckReport, apply_self_update, check_self_update, default_self_update_staging_dir,
-    relaunch_current_executable, stage_self_update,
+    relaunch_current_executable, resolve_self_update_release_notes, stage_self_update,
 };
 use rabbit_core::setup::{SetupOptions, SetupReport, setup_requires_extension_support};
 use rabbit_core::version::Version;
@@ -1812,6 +1812,18 @@ pub fn execute_wizard_install_with_progress(
 pub fn run_wizard_self_update_check() -> Result<SelfUpdateCheckReport> {
     let platform = Platform::current().ok_or(RabbitError::UnsupportedPlatform)?;
     check_self_update(platform, DEFAULT_SELF_UPDATE_MANIFEST_URL)
+}
+
+/// What's-New notes for a pending RABBIT update, covering every release
+/// between the running version and the latest one.
+///
+/// Called from the same startup worker thread as
+/// [`run_wizard_self_update_check`], never from the UI thread: it performs an
+/// HTTP round-trip, and the wizard must stay responsive while it runs. The
+/// result is best-effort — `None` simply means the prompt falls back to its
+/// plain version-to-version wording.
+pub fn run_wizard_self_update_release_notes(report: &SelfUpdateCheckReport) -> Option<String> {
+    resolve_self_update_release_notes(report)
 }
 
 pub fn run_wizard_self_update_apply() -> Result<SelfUpdateApplyReport> {

--- a/crates/rabbit-ui-wxdragon/src/wx_app.rs
+++ b/crates/rabbit-ui-wxdragon/src/wx_app.rs
@@ -3399,9 +3399,24 @@ fn start_self_update_apply(
 ) {
     append_done_status(&done_status, &model.text.done_self_update_apply_running);
     self_update_status.set_status_text(&model.text.done_self_update_apply_running, 0);
+    // Put the progress window up before the worker starts, so the very
+    // first event has somewhere to land. It is modeless: the worker's
+    // completion path runs through `call_after` on this same thread, which
+    // a modal dialog's nested event loop would let run but would also trap
+    // the exit-after-relaunch behind its own dismissal.
+    open_self_update_progress_window(&model);
     let model_for_thread = Arc::clone(&model);
     std::thread::spawn(move || {
-        let result = run_wizard_self_update_apply();
+        // Every event crosses back to the UI thread — widgets must not be
+        // touched from here — and `ProgressEvent` is `Send`, so it rides
+        // inside the `call_after` closure.
+        let progress = ProgressReporter::new(|event| {
+            wxdragon::call_after(Box::new(move || {
+                update_self_update_progress_window(&event);
+            }));
+        });
+        let result = run_wizard_self_update_apply(&progress);
+        wxdragon::call_after(Box::new(close_self_update_progress_window));
         wxdragon::call_after(Box::new(move || match result {
             Ok(report) => {
                 with_ui_localizer(|localizer| {
@@ -3444,6 +3459,226 @@ fn start_self_update_apply(
             }
         }));
     });
+}
+
+/// Widgets of the live self-update progress window. Held in a thread-local
+/// because none of them are `Send`: the worker thread never touches them,
+/// it only posts `ProgressEvent`s through `call_after`, and the closure
+/// that runs on the UI thread picks the widgets up from here.
+struct SelfUpdateProgressWindow {
+    dialog: Dialog,
+    status: StaticText,
+    gauge: Gauge,
+    log: TextCtrl,
+    /// Localized product name, resolved once at construction so each event
+    /// doesn't have to go back through the localizer for it.
+    app_name: String,
+}
+
+thread_local! {
+    static SELF_UPDATE_PROGRESS: RefCell<Option<SelfUpdateProgressWindow>> =
+        const { RefCell::new(None) };
+}
+
+/// Share of the bar given to the download. The remainder covers the
+/// install, which is a single opaque step: the bar jumps to this mark when
+/// the bytes are in and finishes when the swap is done.
+const SELF_UPDATE_DOWNLOAD_SHARE: i32 = 90;
+
+/// Put up the update progress window: a status line, a bar, and a running
+/// log of the phases as they complete.
+///
+/// The same three-part shape as the wizard's own progress page, for the
+/// same reason — the bar is what a sighted user reads, while the log is
+/// what a screen reader can be walked through afterwards, line by line,
+/// which a bar alone never affords. Modeless, and it takes no buttons: the
+/// update cannot be cancelled once started (nothing in the core can unwind
+/// a half-applied swap), so a Cancel button would be a lie.
+fn open_self_update_progress_window(model: &Arc<WizardModel>) {
+    close_self_update_progress_window();
+    with_ui_frame(|frame| {
+        with_ui_localizer(|localizer| {
+            let title = localizer.text("wizard-self-update-progress-title").value;
+            let app_name = localizer.text("app-short-name").value;
+            let dialog = Dialog::builder(frame, &title)
+                .with_style(DialogStyle::Caption | DialogStyle::ResizeBorder)
+                .with_size(460, 260)
+                .build();
+            let panel = Panel::builder(&dialog).build();
+            let sizer = BoxSizer::builder(Orientation::Vertical).build();
+
+            let status = StaticText::builder(&panel)
+                .with_label(&model.text.done_self_update_apply_running)
+                .build();
+            status.set_name("rabbit-self-update-progress-status");
+            sizer.add(&status, 0, SizerFlag::All | SizerFlag::Expand, 6);
+
+            let gauge = Gauge::builder(&panel).with_range(100).build();
+            gauge.set_name("rabbit-self-update-progress-gauge");
+            sizer.add(&gauge, 0, SizerFlag::All | SizerFlag::Expand, 6);
+
+            let log = TextCtrl::builder(&panel)
+                .with_value("")
+                .with_style(
+                    TextCtrlStyle::MultiLine | TextCtrlStyle::ReadOnly | TextCtrlStyle::WordWrap,
+                )
+                .build();
+            log.set_name(&title);
+            sizer.add(&log, 1, SizerFlag::All | SizerFlag::Expand, 6);
+
+            panel.set_sizer(sizer, true);
+            let dialog_sizer = BoxSizer::builder(Orientation::Vertical).build();
+            dialog_sizer.add(&panel, 1, SizerFlag::Expand, 0);
+            dialog.set_sizer(dialog_sizer, true);
+
+            // No Cancel button also means Escape does nothing: wxWidgets
+            // answers it by emulating a click on the escape-id button, and
+            // there is none here. That is the behaviour we want — dismissing
+            // the window would leave the update running unreported.
+            dialog.show(true);
+            log.set_focus();
+
+            SELF_UPDATE_PROGRESS.with(|cell| {
+                *cell.borrow_mut() = Some(SelfUpdateProgressWindow {
+                    dialog,
+                    status,
+                    gauge,
+                    log,
+                    app_name,
+                });
+            });
+        });
+    });
+}
+
+/// Fold one progress event into the window. Silently does nothing when no
+/// window is up — events can still be in flight when it has been closed.
+fn update_self_update_progress_window(event: &ProgressEvent) {
+    SELF_UPDATE_PROGRESS.with(|cell| {
+        let borrowed = cell.borrow();
+        let Some(window) = borrowed.as_ref() else {
+            return;
+        };
+        with_ui_localizer(|localizer| {
+            let package = window.app_name.as_str();
+            match event {
+                ProgressEvent::DownloadStarted { .. } => {
+                    window.gauge.set_value(0);
+                    window.status.set_label(
+                        &localizer
+                            .format(
+                                "wizard-progress-status-downloading",
+                                &[("package", package)],
+                            )
+                            .value,
+                    );
+                    // Only the phase change is logged; the byte ticks below
+                    // would flood a screen reader reading the log.
+                    append_self_update_progress_log(
+                        window,
+                        &localizer
+                            .format(
+                                "wizard-progress-log-download-started",
+                                &[("package", package)],
+                            )
+                            .value,
+                    );
+                }
+                ProgressEvent::DownloadProgress {
+                    bytes_downloaded,
+                    bytes_total,
+                    ..
+                } => {
+                    // Without a Content-Length there is no fraction to show,
+                    // so the bar stays where it is and the byte counter in
+                    // the status line carries the news instead.
+                    if let Some(total) = bytes_total.filter(|total| *total > 0) {
+                        let ratio = (*bytes_downloaded as f64 / total as f64).clamp(0.0, 1.0);
+                        window
+                            .gauge
+                            .set_value((ratio * SELF_UPDATE_DOWNLOAD_SHARE as f64) as i32);
+                    }
+                    let downloaded = format_bytes_human(*bytes_downloaded);
+                    let total = bytes_total.map_or_else(|| "?".to_string(), format_bytes_human);
+                    window.status.set_label(
+                        &localizer
+                            .format(
+                                "wizard-progress-status-downloading-with-bytes",
+                                &[
+                                    ("package", package),
+                                    ("downloaded", downloaded.as_str()),
+                                    ("total", total.as_str()),
+                                ],
+                            )
+                            .value,
+                    );
+                }
+                ProgressEvent::DownloadCompleted { .. } => {
+                    window.gauge.set_value(SELF_UPDATE_DOWNLOAD_SHARE);
+                    append_self_update_progress_log(
+                        window,
+                        &localizer
+                            .format(
+                                "wizard-progress-log-download-completed",
+                                &[("package", package)],
+                            )
+                            .value,
+                    );
+                }
+                ProgressEvent::InstallStarted { .. } => {
+                    window.status.set_label(
+                        &localizer
+                            .format("wizard-progress-status-installing", &[("package", package)])
+                            .value,
+                    );
+                    append_self_update_progress_log(
+                        window,
+                        &localizer
+                            .format(
+                                "wizard-progress-log-install-started",
+                                &[("package", package)],
+                            )
+                            .value,
+                    );
+                }
+                ProgressEvent::InstallCompleted { .. } => {
+                    window.gauge.set_value(100);
+                    append_self_update_progress_log(
+                        window,
+                        &localizer
+                            .format(
+                                "wizard-progress-log-install-completed",
+                                &[("package", package)],
+                            )
+                            .value,
+                    );
+                }
+                // Configuration steps belong to package installs; RABBIT's
+                // own update never emits them.
+                ProgressEvent::ConfigurationStarted { .. }
+                | ProgressEvent::ConfigurationCompleted { .. } => {}
+            }
+        });
+    });
+}
+
+/// Append one line to the progress window's log, keeping the newest line in
+/// view.
+fn append_self_update_progress_log(window: &SelfUpdateProgressWindow, line: &str) {
+    let existing = window.log.get_value();
+    let separator = if existing.is_empty() { "" } else { "\n" };
+    window
+        .log
+        .set_value(&format!("{existing}{separator}{line}"));
+}
+
+/// Tear the progress window down. Safe to call when none is up, and safe to
+/// call twice — the second call finds the slot empty.
+fn close_self_update_progress_window() {
+    let window = SELF_UPDATE_PROGRESS.with(|cell| cell.borrow_mut().take());
+    if let Some(window) = window {
+        window.dialog.destroy();
+    }
 }
 
 /// macOS: tell Cocoa what language this process is running in by setting the

--- a/crates/rabbit-ui-wxdragon/src/wx_app.rs
+++ b/crates/rabbit-ui-wxdragon/src/wx_app.rs
@@ -131,7 +131,8 @@ use crate::{
     install_request_from_target_and_rows, load_wizard_model, localized_package_display_name,
     localizer_from_options, osara_keymap_note, osara_selected_for_rows,
     reapack_selected_for_install_or_update, refreshed_target_row, relaunch_rabbit_after_apply,
-    run_wizard_self_update_apply, run_wizard_self_update_check, save_wizard_outcome_report,
+    run_wizard_self_update_apply, run_wizard_self_update_check,
+    run_wizard_self_update_release_notes, save_wizard_outcome_report,
     selected_configuration_step_ids, wizard_desired_package_ids, wizard_outcome_report_from_error,
     wizard_outcome_report_from_success, wizard_package_plan_for_target,
     wizard_package_plan_for_target_with_available,
@@ -179,6 +180,10 @@ struct SelfUpdateUiState {
     /// startup probe is still running; `Some(Ok)` on success; `Some(Err)`
     /// carries the formatted error message (RabbitError isn't Clone).
     check: Option<std::result::Result<SelfUpdateCheckReport, String>>,
+    /// What's-New notes for the pending update, resolved by the same startup
+    /// worker as `check`. `None` when there is no update, or when the notes
+    /// couldn't be fetched — the prompt then falls back to its plain form.
+    release_notes: Option<String>,
     /// Last status string written to the status bar — used to suppress
     /// screen-reader re-announcements when nothing has changed.
     last_status: String,
@@ -235,6 +240,7 @@ fn render_self_update_status(
     }
     state_guard.prompted = true;
     let Ok(report) = check else { return };
+    let release_notes = state_guard.release_notes.clone();
     // Drop the lock before showing the modal — `MessageDialog::show_modal`
     // runs a nested wxWidgets event loop, and any UI-thread callback that
     // re-enters `render_self_update_status` while the modal is open would
@@ -257,15 +263,25 @@ fn render_self_update_status(
     // closure runs on the UI thread, so the thread-local was populated
     // by `run()` before any worker fired.
     with_ui_frame(|frame| {
-        let dialog = MessageDialog::builder(frame, &body, &title)
-            .with_style(
-                MessageDialogStyle::YesNo
-                    | MessageDialogStyle::IconQuestion
-                    | MessageDialogStyle::Centre,
-            )
-            .build();
+        let accepted = match release_notes.as_deref() {
+            Some(notes) => {
+                show_self_update_prompt_with_notes(frame, localizer, &title, &body, &current, notes)
+            }
+            // No notes to show (fetch failed, or the release carries no
+            // body): the plain native message box, exactly as before.
+            None => {
+                let dialog = MessageDialog::builder(frame, &body, &title)
+                    .with_style(
+                        MessageDialogStyle::YesNo
+                            | MessageDialogStyle::IconQuestion
+                            | MessageDialogStyle::Centre,
+                    )
+                    .build();
+                dialog.show_modal() == ID_YES
+            }
+        };
 
-        if dialog.show_modal() == ID_YES {
+        if accepted {
             start_self_update_apply(
                 widgets.done_status,
                 widgets.self_update_status,
@@ -273,6 +289,145 @@ fn render_self_update_status(
             );
         }
     });
+}
+
+/// The update prompt in its rich form: the same question the plain message
+/// box asks, plus the release notes for everything the update brings, so the
+/// answer to "should I say yes?" is on screen when the question is asked.
+/// Returns `true` when the user accepted.
+///
+/// A `wxMessageDialog` can't host this — its message is a single unscrollable
+/// static label, and RABBIT's release notes routinely run past a screenful.
+/// Hence a plain `Dialog` carrying a read-only multiline `TextCtrl`, which is
+/// the same control (and therefore the same screen-reader behaviour) the
+/// packages page already uses for a package's What's-New notes.
+///
+/// Accessibility notes, in the spirit of the Done page:
+/// - Focus parks on the notes control, so the screen reader reads what the
+///   update contains instead of announcing a bare button.
+/// - The notes control's accessible name carries the heading, since a
+///   `StaticText` label sits outside the tab order and would otherwise never
+///   be announced.
+/// - Update is the default button, so Enter accepts from anywhere in the
+///   dialog, and Escape maps to Later.
+fn show_self_update_prompt_with_notes(
+    frame: &Frame,
+    localizer: &Localizer,
+    title: &str,
+    body: &str,
+    current: &str,
+    notes: &str,
+) -> bool {
+    let notes_heading = localizer
+        .format(
+            "wizard-self-update-prompt-notes-heading",
+            &[("current", current)],
+        )
+        .value;
+    let update_label = localizer
+        .text("wizard-self-update-prompt-update-button")
+        .value;
+    let later_label = localizer
+        .text("wizard-self-update-prompt-later-button")
+        .value;
+
+    let dialog = Dialog::builder(frame, title)
+        // Resizable so a long set of notes can be opened up, rather than
+        // forcing everything through one fixed-height scroll region.
+        .with_style(DialogStyle::DefaultDialogStyle | DialogStyle::ResizeBorder)
+        .with_size(560, 420)
+        .build();
+    // Controls go on a child Panel rather than straight onto the dialog:
+    // that's what gives MSW its dialog-navigation behaviour (Tab/arrow
+    // traversal between the notes and the buttons) for free.
+    let panel = Panel::builder(&dialog).build();
+    let sizer = BoxSizer::builder(Orientation::Vertical).build();
+
+    let question = StaticText::builder(&panel).with_label(body).build();
+    question.set_name("rabbit-self-update-prompt-question");
+    sizer.add(&question, 0, SizerFlag::All | SizerFlag::Expand, 6);
+
+    let heading = StaticText::builder(&panel)
+        .with_label(&notes_heading)
+        .build();
+    heading.set_name("rabbit-self-update-prompt-notes-heading");
+    sizer.add(&heading, 0, SizerFlag::All | SizerFlag::Expand, 6);
+
+    let notes_text = TextCtrl::builder(&panel)
+        .with_value(notes)
+        .with_style(TextCtrlStyle::MultiLine | TextCtrlStyle::ReadOnly | TextCtrlStyle::WordWrap)
+        .build();
+    notes_text.set_name(&notes_heading);
+    sizer.add(&notes_text, 1, SizerFlag::All | SizerFlag::Expand, 6);
+
+    // The buttons carry the standard yes/no ids rather than generated ones
+    // so `set_escape_id` below has something to act on: wxWidgets answers
+    // Escape by emulating a click on the button holding the escape id, and
+    // does nothing at all when no button has it.
+    //
+    // `TabStop` + `set_can_focus` for the same reason the wizard's own
+    // navigation buttons carry them: without it macOS leaves buttons out of
+    // the Tab ring unless Full Keyboard Access is on.
+    let buttons = BoxSizer::builder(Orientation::Horizontal).build();
+    let update = Button::builder(&panel)
+        .with_id(ID_YES)
+        .with_label(&update_label)
+        .build();
+    update.set_name("rabbit-self-update-prompt-update");
+    update.add_style(WindowStyle::TabStop);
+    update.set_can_focus(true);
+    buttons.add(&update, 0, SizerFlag::All, 6);
+    let later = Button::builder(&panel)
+        .with_id(ID_NO)
+        .with_label(&later_label)
+        .build();
+    later.set_name("rabbit-self-update-prompt-later");
+    later.add_style(WindowStyle::TabStop);
+    later.set_can_focus(true);
+    buttons.add(&later, 0, SizerFlag::All, 6);
+    sizer.add_sizer(&buttons, 0, SizerFlag::AlignRight, 0);
+
+    panel.set_sizer(sizer, true);
+    // Same frame → panel → content nesting `run()` builds for the wizard
+    // window: the dialog's own sizer is what makes the panel track the
+    // dialog when it is resized.
+    let dialog_sizer = BoxSizer::builder(Orientation::Vertical).build();
+    dialog_sizer.add(&panel, 1, SizerFlag::Expand, 0);
+    dialog.set_sizer(dialog_sizer, true);
+
+    // `Dialog` is `Copy`, so each `move` handler closes over its own copy
+    // and the original stays usable below. Neither handler skips the event,
+    // so it stops at the button and wxDialog's own button handling never
+    // gets a second go at ending the modal.
+    update.on_click(move |_| dialog.end_modal(ID_YES));
+    later.on_click(move |_| dialog.end_modal(ID_NO));
+    dialog.set_affirmative_id(ID_YES);
+    dialog.set_escape_id(ID_NO);
+    update.set_default();
+
+    // A multiline TextCtrl claims Enter for itself (DLGC_WANTALLKEYS on
+    // MSW, the NSTextView swallows it on macOS), so the default button
+    // never sees the key while focus is parked on the notes — the same
+    // trap `bind_done_page_enter_closes` works around on the Done page.
+    notes_text.on_key_down(move |event| {
+        let key_code = if let WindowEventData::Keyboard(kbd) = &event {
+            kbd.get_key_code()
+        } else {
+            None
+        };
+        if !matches!(key_code, Some(WXK_RETURN) | Some(WXK_NUMPAD_ENTER)) {
+            return;
+        }
+        // Consume the key so the read-only control neither beeps nor
+        // tries to insert a newline before the dialog closes.
+        event.skip(false);
+        dialog.end_modal(ID_YES);
+    });
+
+    notes_text.set_focus();
+    let accepted = dialog.show_modal() == ID_YES;
+    dialog.destroy();
+    accepted
 }
 
 /// `wx/defs.h`: `WXK_SPACE = 32` (just the ASCII value). Kept around as a
@@ -2197,8 +2352,18 @@ pub fn run() {
             let state = Arc::clone(&self_update_state);
             std::thread::spawn(move || {
                 let check = run_wizard_self_update_check();
+                // Resolve the What's-New notes on this same worker, while
+                // the status line still reads "Checking for RABBIT
+                // updates…": the prompt is only raised once the whole probe
+                // lands on the UI thread, so fetching notes here costs the
+                // user nothing and spares the UI thread an HTTP round-trip.
+                let release_notes = check
+                    .as_ref()
+                    .ok()
+                    .and_then(run_wizard_self_update_release_notes);
                 {
                     let mut state = state.lock().unwrap();
+                    state.release_notes = release_notes;
                     state.check = Some(match check {
                         Ok(report) => Ok(report),
                         Err(error) => Err(error.to_string()),

--- a/locales/de-DE/rabbit.ftl
+++ b/locales/de-DE/rabbit.ftl
@@ -253,6 +253,11 @@ wizard-self-update-prompt-notes-heading = Neuerungen seit RABBIT { $current }:
 wizard-self-update-prompt-update-button = Jetzt aktualisieren
 wizard-self-update-prompt-later-button = Jetzt nicht
 
+# Title of the modeless window shown while RABBIT downloads and installs
+# its own update. It doubles as the accessible name of the progress log
+# inside it, so it has to read well on its own.
+wizard-self-update-progress-title = RABBIT wird aktualisiert
+
 # $current is the running RABBIT version, $latest is the version offered by the
 # release manifest, $channel is the release channel id (e.g. "stable").
 self-update-status-update-available = RABBIT-Aktualisierung verfügbar: { $current } → { $latest } (Kanal { $channel }). Starten Sie RABBIT neu, um erneut gefragt zu werden.

--- a/locales/de-DE/rabbit.ftl
+++ b/locales/de-DE/rabbit.ftl
@@ -245,6 +245,14 @@ wizard-self-update-status-checking = Suche nach RABBIT-Aktualisierungen…
 wizard-self-update-prompt-title = RABBIT-Aktualisierung verfügbar
 wizard-self-update-prompt-body = RABBIT { $latest } ist verfügbar. Sie haben aktuell { $current }. Jetzt aktualisieren? RABBIT wird nach Abschluss der Aktualisierung neu gestartet.
 
+# Shown in the update prompt when the release notes could be fetched. The
+# heading doubles as the accessible name of the read-only notes box, so it
+# has to read well on its own; $current is the running version, since the
+# notes cover every release published since then.
+wizard-self-update-prompt-notes-heading = Neuerungen seit RABBIT { $current }:
+wizard-self-update-prompt-update-button = Jetzt aktualisieren
+wizard-self-update-prompt-later-button = Jetzt nicht
+
 # $current is the running RABBIT version, $latest is the version offered by the
 # release manifest, $channel is the release channel id (e.g. "stable").
 self-update-status-update-available = RABBIT-Aktualisierung verfügbar: { $current } → { $latest } (Kanal { $channel }). Starten Sie RABBIT neu, um erneut gefragt zu werden.

--- a/locales/en-US/rabbit.ftl
+++ b/locales/en-US/rabbit.ftl
@@ -253,6 +253,11 @@ wizard-self-update-prompt-notes-heading = What's new since RABBIT { $current }:
 wizard-self-update-prompt-update-button = Update now
 wizard-self-update-prompt-later-button = Not now
 
+# Title of the modeless window shown while RABBIT downloads and installs
+# its own update. It doubles as the accessible name of the progress log
+# inside it, so it has to read well on its own.
+wizard-self-update-progress-title = Updating RABBIT
+
 # $current is the running RABBIT version, $latest is the version offered by the
 # release manifest, $channel is the release channel id (e.g. "stable").
 self-update-status-update-available = RABBIT update available: { $current } → { $latest } (channel { $channel }). Relaunch RABBIT to be re-prompted.

--- a/locales/en-US/rabbit.ftl
+++ b/locales/en-US/rabbit.ftl
@@ -245,6 +245,14 @@ wizard-self-update-status-checking = Checking for RABBIT updates…
 wizard-self-update-prompt-title = RABBIT update available
 wizard-self-update-prompt-body = RABBIT { $latest } is available. You currently have { $current }. Update now? RABBIT will relaunch when the update finishes.
 
+# Shown in the update prompt when the release notes could be fetched. The
+# heading doubles as the accessible name of the read-only notes box, so it
+# has to read well on its own; $current is the running version, since the
+# notes cover every release published since then.
+wizard-self-update-prompt-notes-heading = What's new since RABBIT { $current }:
+wizard-self-update-prompt-update-button = Update now
+wizard-self-update-prompt-later-button = Not now
+
 # $current is the running RABBIT version, $latest is the version offered by the
 # release manifest, $channel is the release channel id (e.g. "stable").
 self-update-status-update-available = RABBIT update available: { $current } → { $latest } (channel { $channel }). Relaunch RABBIT to be re-prompted.

--- a/locales/es-ES/rabbit.ftl
+++ b/locales/es-ES/rabbit.ftl
@@ -253,6 +253,11 @@ wizard-self-update-prompt-notes-heading = Novedades desde RABBIT { $current }:
 wizard-self-update-prompt-update-button = Actualizar ahora
 wizard-self-update-prompt-later-button = Ahora no
 
+# Title of the modeless window shown while RABBIT downloads and installs
+# its own update. It doubles as the accessible name of the progress log
+# inside it, so it has to read well on its own.
+wizard-self-update-progress-title = Actualizando RABBIT
+
 # $current is the running RABBIT version, $latest is the version offered by the
 # release manifest, $channel is the release channel id (e.g. "stable").
 self-update-status-update-available = Actualización de RABBIT disponible: { $current } → { $latest } (Canal { $channel }). Reinicia RABBIT para volver a preguntar.

--- a/locales/es-ES/rabbit.ftl
+++ b/locales/es-ES/rabbit.ftl
@@ -245,6 +245,14 @@ wizard-self-update-status-checking = Comprobando actualizaciones de RABBIT…
 wizard-self-update-prompt-title = Actualización de RABBIT disponible
 wizard-self-update-prompt-body = RABBIT { $latest } está disponible. Ahora tienes { $current }. ¿Quieres actualizar? RABBIT se va a reiniciar cuando termine la actualización.
 
+# Shown in the update prompt when the release notes could be fetched. The
+# heading doubles as the accessible name of the read-only notes box, so it
+# has to read well on its own; $current is the running version, since the
+# notes cover every release published since then.
+wizard-self-update-prompt-notes-heading = Novedades desde RABBIT { $current }:
+wizard-self-update-prompt-update-button = Actualizar ahora
+wizard-self-update-prompt-later-button = Ahora no
+
 # $current is the running RABBIT version, $latest is the version offered by the
 # release manifest, $channel is the release channel id (e.g. "stable").
 self-update-status-update-available = Actualización de RABBIT disponible: { $current } → { $latest } (Canal { $channel }). Reinicia RABBIT para volver a preguntar.

--- a/locales/fr-FR/rabbit.ftl
+++ b/locales/fr-FR/rabbit.ftl
@@ -245,6 +245,14 @@ wizard-self-update-status-checking = Recherche de mises à jour de RABBIT…
 wizard-self-update-prompt-title = Mise à jour de RABBIT disponible
 wizard-self-update-prompt-body = RABBIT { $latest } est disponible. Vous avez actuellement { $current }. Mettre à jour maintenant ? RABBIT redémarrera une fois la mise à jour terminée.
 
+# Shown in the update prompt when the release notes could be fetched. The
+# heading doubles as the accessible name of the read-only notes box, so it
+# has to read well on its own; $current is the running version, since the
+# notes cover every release published since then.
+wizard-self-update-prompt-notes-heading = Nouveautés depuis RABBIT { $current } :
+wizard-self-update-prompt-update-button = Mettre à jour maintenant
+wizard-self-update-prompt-later-button = Plus tard
+
 # $current is the running RABBIT version, $latest is the version offered by the
 # release manifest, $channel is the release channel id (e.g. "stable").
 self-update-status-update-available = Mise à jour de RABBIT disponible : { $current } → { $latest } (canal { $channel }). Relancez RABBIT pour être invité à nouveau.

--- a/locales/fr-FR/rabbit.ftl
+++ b/locales/fr-FR/rabbit.ftl
@@ -253,6 +253,11 @@ wizard-self-update-prompt-notes-heading = Nouveautés depuis RABBIT { $current }
 wizard-self-update-prompt-update-button = Mettre à jour maintenant
 wizard-self-update-prompt-later-button = Plus tard
 
+# Title of the modeless window shown while RABBIT downloads and installs
+# its own update. It doubles as the accessible name of the progress log
+# inside it, so it has to read well on its own.
+wizard-self-update-progress-title = Mise à jour de RABBIT
+
 # $current is the running RABBIT version, $latest is the version offered by the
 # release manifest, $channel is the release channel id (e.g. "stable").
 self-update-status-update-available = Mise à jour de RABBIT disponible : { $current } → { $latest } (canal { $channel }). Relancez RABBIT pour être invité à nouveau.

--- a/locales/it-IT/rabbit.ftl
+++ b/locales/it-IT/rabbit.ftl
@@ -253,6 +253,11 @@ wizard-self-update-prompt-notes-heading = Novità da RABBIT { $current }:
 wizard-self-update-prompt-update-button = Aggiorna ora
 wizard-self-update-prompt-later-button = Non ora
 
+# Title of the modeless window shown while RABBIT downloads and installs
+# its own update. It doubles as the accessible name of the progress log
+# inside it, so it has to read well on its own.
+wizard-self-update-progress-title = Aggiornamento di RABBIT
+
 # $current is the running RABBIT version, $latest is the version offered by the
 # release manifest, $channel is the release channel id (e.g. "stable").
 self-update-status-update-available = Aggiornamento di RABBIT disponibile: { $current } → { $latest } (canale { $channel }). Riavvia RABBIT per ricevere di nuovo la richiesta.

--- a/locales/it-IT/rabbit.ftl
+++ b/locales/it-IT/rabbit.ftl
@@ -245,6 +245,14 @@ wizard-self-update-status-checking = Ricerca di aggiornamenti di RABBIT…
 wizard-self-update-prompt-title = Aggiornamento di RABBIT disponibile
 wizard-self-update-prompt-body = RABBIT { $latest } è disponibile. Attualmente hai { $current }. Aggiornare ora? RABBIT si riavvierà al termine dell'aggiornamento.
 
+# Shown in the update prompt when the release notes could be fetched. The
+# heading doubles as the accessible name of the read-only notes box, so it
+# has to read well on its own; $current is the running version, since the
+# notes cover every release published since then.
+wizard-self-update-prompt-notes-heading = Novità da RABBIT { $current }:
+wizard-self-update-prompt-update-button = Aggiorna ora
+wizard-self-update-prompt-later-button = Non ora
+
 # $current is the running RABBIT version, $latest is the version offered by the
 # release manifest, $channel is the release channel id (e.g. "stable").
 self-update-status-update-available = Aggiornamento di RABBIT disponibile: { $current } → { $latest } (canale { $channel }). Riavvia RABBIT per ricevere di nuovo la richiesta.


### PR DESCRIPTION
> **Stacked on #20.** This branch contains that PR's commit as its base, so the diff here shows both. Merging #20 first leaves this one with a single commit; reviewing them in that order avoids reading the first change twice.

Accepting the update prompt writes one line into the status bar and then goes quiet for however long a 10 MB download takes, with nothing to say whether anything is happening. This adds a progress window: the current phase, a bar, and a log of completed steps.

### What changes

- A modeless window opens when the update starts: `Downloading RABBIT… 4.1 MB of 10.2 MB`, a gauge that fills as bytes arrive, and one log line per completed phase. It closes itself when RABBIT relaunches into the new version.
- Sparkle's shape, but built on wxWidgets so Windows gets the same treatment.

### How it's wired

Almost nothing new: `download_url_with_retries` already speaks `ProgressEvent`, and self-update was handing it a `ProgressReporter::noop()`. Staging and apply now thread a real reporter through, borrowing the package slot under `SELF_UPDATE_PROGRESS_ID` instead of growing a parallel event type — which also means the window reuses the wizard's existing progress FTL strings. One new key, for the window title.

`DownloadCompleted` now fires **after** the checksum rather than after the last byte, so the bar doesn't sit finished while a 10 MB file is hashed. The reused-artifact and local-file paths report a started/completed pair too, so the window never shows an empty bar with nothing behind it.

### Notable decisions

- **No Cancel button, and no escape id.** Nothing in the core can unwind a half-applied swap, so a button that couldn't do what it says is worse than no button. If you'd like cancellation, the download half is feasible — `fetch_remote_artifact_with_retries` already takes a cancel flag — but the apply half isn't, and a Cancel that only sometimes works seemed worse than none.
- **Modeless.** The worker's completion path runs through `call_after` on the UI thread; a modal's nested event loop would trap the exit-after-relaunch behind its own dismissal.
- **A log line per phase**, for the same reason the wizard's progress page has one: a gauge is unreadable to a screen reader, a growing list of finished steps is not.
- `ApplySelfUpdateOptions` gained an optional `progress` field rather than a new function, so existing call sites only needed `..Default::default()`.

### Testing

CI green (fmt, clippy, clippy with the `gui` feature, tests, builds) on macOS and Windows. Validated by hand on macOS with VoiceOver in fr-FR: a build with its version forced down ran the full path — prompt, download with live byte counts, install, relaunch — and the resulting app was the real notarized 0.4.0, Gatekeeper-accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)