### PR TITLE
feat(packages): add the French REAPER language pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,16 @@ from this file and posts it as the GitHub release body.
   (`depends_on`) than emphasis, and a link's address is dropped while the
   text you would have clicked is kept.
 
+- A **French REAPER language pack** joins the Spanish and German ones, so
+  REAPER and the SWS extension speak French too. It is maintained by Lee
+  Julien and Pierre-Marie Curt for ReaperAccessible, the French
+  screen-reader community. RABBIT installs it as `fr_CA.ReaperLangPack`,
+  the name that makes OSARA load its own French translation — the `fr_CA`
+  one, which is all but complete where OSARA's `fr_FR` translation still
+  leaves about a third of its messages in English. Unlike the other two
+  packs, this one is published with a version number, which RABBIT reads
+  from ReaperAccessible's ReaPack index and shows in the wizard.
+
 ### Fixed
 
 - macOS: the app bundle now declares Spanish, so VoiceOver reads RABBIT's

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ locations rather than into the portable REAPER folder.
 ### Language packs
 
 RABBIT can also translate **REAPER itself** (not just its own wizard), by
-installing a community language pack into `<resource>/LangPack/`. Two are
-available today, and both translate the SWS extension as well:
+installing a community language pack into `<resource>/LangPack/`. Three are
+available today, and all of them translate the SWS extension as well:
 
 - **Spanish** — maintained by Javier Robledo for the Spanish REAPER
   community and published on
@@ -68,6 +68,16 @@ available today, and both translate the SWS extension as well:
 - **German** — maintained by MrData and published in the
   [REAPER Stash](https://stash.reaper.fm/v/26248/), installed as
   `de_DE.ReaperLangPack`.
+- **French** — maintained by Lee Julien and Pierre-Marie Curt for
+  [ReaperAccessible](https://reaperaccessible.fr/), the French
+  screen-reader community, and published in their
+  [ReaPack repository](https://github.com/reaperaccessible/rap_fr).
+  Installed as `fr_CA.ReaperLangPack`, which is what makes **OSARA** load
+  its `fr_CA` translation: that one is all but complete, while OSARA's
+  `fr_FR` translation still leaves about a third of its messages in
+  English. The pack itself is the same standard French under either name —
+  only OSARA's own strings differ, and a few of them are Canadian
+  (*muté*, *soloté*).
 
 The pack matching the language RABBIT is running in is suggested and
 ticked for you; packs for other languages are listed but unticked. Nothing
@@ -78,12 +88,14 @@ previous one **RABBIT** installed — a pack you dropped into `LangPack/`
 yourself is never touched. By default RABBIT also sets the pack as
 REAPER's language (see the configuration step below).
 
-These packs are published without version numbers, so RABBIT identifies
-them by what the server reports about the file (its ETag or last-modified
-date and size, falling back to the file's contents): it notices when a
-translator publishes a new file and offers it as an update, without RABBIT
-needing a new release. Your choice of Spanish translation is remembered, so
-an update keeps the variant you picked instead of reverting to the default.
+The Spanish and German packs are published without version numbers, so
+RABBIT identifies them by what the server reports about the file (its ETag
+or last-modified date and size, falling back to the file's contents): it
+notices when a translator publishes a new file and offers it as an update,
+without RABBIT needing a new release. The French pack does carry a version
+(`7.75.1` at the time of writing), read from its ReaPack index. Your choice
+of Spanish translation is remembered, so an update keeps the variant you
+picked instead of reverting to the default.
 
 Beyond installing packages, RABBIT can also apply small post-install
 configuration tweaks:

--- a/crates/rabbit-core/embedded/packages/102-langpack-fr.json
+++ b/crates/rabbit-core/embedded/packages/102-langpack-fr.json
@@ -1,0 +1,95 @@
+{
+  "id": "langpack-fr",
+  "display_name": "REAPER en français",
+  "display_name_key": "package-langpack-fr",
+  "display_description_key": "package-langpack-fr-description",
+  "package_kind": "language_pack",
+  "install_destination": "lang_pack",
+  "depends_on": [
+    "reaper"
+  ],
+  "exclusive_group": "reaper-langpack",
+  "language": "fr",
+  "install_as": "fr_CA.ReaperLangPack",
+  "required": false,
+  "recommended": false,
+  "supported_platforms": [
+    "windows",
+    "macos"
+  ],
+  "supported_architectures": [
+    "x86",
+    "x64",
+    "arm64",
+    "arm64-ec",
+    "universal"
+  ],
+  "version": {
+    "html": {
+      "url": "https://raw.githubusercontent.com/reaperaccessible/rap_fr/main/index.xml",
+      "pattern": "V([0-9][0-9.]*) par ReaperAccessible"
+    }
+  },
+  "detectors": [
+    "rabbit_receipt"
+  ],
+  "install_steps": [
+    "copy_user_plugin_binary"
+  ],
+  "uninstall_steps": [
+    "remove_user_plugin_binary"
+  ],
+  "backup_policy": "backup_overwritten_files",
+  "user_plugin_prefixes": [],
+  "user_plugin_suffixes": {
+    "windows": [
+      ".ReaperLangPack"
+    ],
+    "macos": [
+      ".ReaperLangPack"
+    ]
+  },
+  "category": "language",
+  "http_artifact": {
+    "targets": [
+      {
+        "platform": "windows",
+        "match_arches": [
+          "x86",
+          "x64",
+          "arm64",
+          "arm64-ec",
+          "universal",
+          "unknown"
+        ],
+        "report_arch": "universal",
+        "artifact_kind": "extension_binary",
+        "source": {
+          "fixed_url": {
+            "url": "https://raw.githubusercontent.com/reaperaccessible/rap_fr/main/LangPack/REAPER_SWS_FRC.ReaperLangPack",
+            "file_name": "REAPER_SWS_FRC.ReaperLangPack"
+          }
+        }
+      },
+      {
+        "platform": "macos",
+        "match_arches": [
+          "x86",
+          "x64",
+          "arm64",
+          "arm64-ec",
+          "universal",
+          "unknown"
+        ],
+        "report_arch": "universal",
+        "artifact_kind": "extension_binary",
+        "source": {
+          "fixed_url": {
+            "url": "https://raw.githubusercontent.com/reaperaccessible/rap_fr/main/LangPack/REAPER_SWS_FRC.ReaperLangPack",
+            "file_name": "REAPER_SWS_FRC.ReaperLangPack"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/crates/rabbit-core/src/package.rs
+++ b/crates/rabbit-core/src/package.rs
@@ -1364,8 +1364,9 @@ mod tests {
         let manifest = embedded_package_manifest();
 
         assert_eq!(manifest.schema_version, 1);
-        // 9 software packages + the Spanish and German REAPER language packs.
-        assert_eq!(manifest.packages.len(), 11);
+        // 9 software packages + the Spanish, German and French REAPER
+        // language packs.
+        assert_eq!(manifest.packages.len(), 12);
         assert!(
             manifest
                 .packages

--- a/locales/de-DE/rabbit.ftl
+++ b/locales/de-DE/rabbit.ftl
@@ -19,6 +19,7 @@ package-surge-xt = Surge XT
 package-app2clap = app2clap
 package-langpack-es = REAPER auf Spanisch
 package-langpack-de = REAPER auf Deutsch
+package-langpack-fr = REAPER auf Französisch
 package-langpack-es-variant-rae = REAPER Accesible español (es_ES)
 package-langpack-es-variant-pma = Team PMA (es_MX)
 
@@ -33,6 +34,7 @@ package-surge-xt-description = Surge XT ist ein freier, quelloffener Hybrid-Synt
 package-app2clap-description = app2clap ist ein CLAP-Plugin für Windows, das Audio aus anderen Anwendungen erfasst und es in REAPER (oder jeden CLAP-Host) als Plug-in einspeist, das du in eine Spur einfügst — praktisch, um Ton aus einem Browser, Mediaplayer oder anderen Programm aufzunehmen oder zu bearbeiten. RABBIT lädt die neueste Version herunter und installiert app2clap.clap in deinen benutzereigenen CLAP-Ordner, sodass keine Administratorrechte nötig sind. Nur für Windows. Nur Standard-REAPER-Installationen: Die Installation erfolgt außerhalb eines portablen REAPER-Ordners.
 package-langpack-es-description = Übersetzt die Oberfläche von REAPER ins Spanische, einschließlich der SWS-Erweiterung. Betreut von Javier Robledo für die spanische REAPER-Community und über reaperespa.com veröffentlicht — RABBIT lädt die aktuelle Fassung herunter und installiert sie als es_ES.ReaperLangPack. OSARA wählt anhand dieses Dateinamens seine eigene spanische Übersetzung. Stellen Sie die Sprache anschließend in den REAPER-Einstellungen ein (oder lassen Sie RABBIT das übernehmen).
 package-langpack-de-description = Übersetzt die Oberfläche von REAPER ins Deutsche, einschließlich der SWS-Erweiterung. Betreut von MrData und im REAPER-Stash veröffentlicht — RABBIT lädt die aktuelle Fassung herunter und installiert sie als de_DE.ReaperLangPack. Stellen Sie die Sprache anschließend in den REAPER-Einstellungen ein (oder lassen Sie RABBIT das übernehmen).
+package-langpack-fr-description = Übersetzt die Oberfläche von REAPER ins Französische, einschließlich der SWS-Erweiterung. Betreut von Lee Julien und Pierre-Marie Curt für ReaperAccessible, die französische Screenreader-Gemeinschaft, und in deren ReaPack-Repository veröffentlicht — RABBIT lädt die aktuelle Fassung herunter und installiert sie als fr_CA.ReaperLangPack. OSARA wählt anhand dieses Dateinamens seine eigene französische Übersetzung: die fr_CA-Fassung ist nahezu vollständig, während die fr_FR-Fassung noch etwa ein Drittel der Meldungen auf Englisch lässt; das Sprachpaket selbst ist in beiden Fällen dasselbe Standardfranzösisch. Stellen Sie die Sprache anschließend in den REAPER-Einstellungen ein (oder lassen Sie RABBIT das übernehmen).
 
 # $reason is one of the localized "wizard-package-row-unavailable-*" strings
 # explaining *why* the row is unavailable. Appended to the row's main summary
@@ -137,6 +139,8 @@ config-set-reaper-language-es-name = REAPER-Sprache auf Spanisch einstellen
 config-set-reaper-language-es-description = Trägt das spanische Sprachpaket in die reaper.ini ein, damit REAPER es verwendet. Andernfalls müssten Sie die Sprache selbst unter „Optionen“, „Einstellungen“, „Allgemein“ auswählen. Abwählen, wenn nur die Datei installiert werden soll.
 config-set-reaper-language-de-name = REAPER-Sprache auf Deutsch einstellen
 config-set-reaper-language-de-description = Trägt das deutsche Sprachpaket in die reaper.ini ein, damit REAPER es verwendet. Andernfalls müssten Sie die Sprache selbst unter „Optionen“, „Einstellungen“, „Allgemein“ auswählen. Abwählen, wenn nur die Datei installiert werden soll.
+config-set-reaper-language-fr-name = REAPERs Sprache auf Französisch setzen
+config-set-reaper-language-fr-description = Trägt das französische Sprachpaket in die reaper.ini ein, damit REAPER es verwendet. Andernfalls müssten Sie die Sprache selbst unter „Optionen“, „Einstellungen“, „Allgemein“ auswählen. Abwählen, wenn nur die Datei installiert werden soll.
 
 wizard-reapack-ack-heading = ReaPack-Spendenhinweis
 wizard-reapack-ack-body = ReaPack ist freie Software und steht unter der LGPL. Sein Autor Christian Fillion nimmt Spenden zur Unterstützung der Weiterentwicklung an. Spenden sind vollständig freiwillig und für die Nutzung von ReaPack oder RABBIT niemals erforderlich.

--- a/locales/en-US/rabbit.ftl
+++ b/locales/en-US/rabbit.ftl
@@ -19,6 +19,7 @@ package-surge-xt = Surge XT
 package-app2clap = app2clap
 package-langpack-es = REAPER in Spanish
 package-langpack-de = REAPER in German
+package-langpack-fr = REAPER in French
 package-langpack-es-variant-rae = REAPER Accesible español (es_ES)
 package-langpack-es-variant-pma = Team PMA (es_MX)
 
@@ -33,6 +34,7 @@ package-surge-xt-description = Surge XT is a free, open-source hybrid synthesize
 package-app2clap-description = app2clap is a CLAP plug-in for Windows that captures audio from other applications and brings it into REAPER (or any CLAP host) as a plug-in you insert on a track — handy for recording or processing sound from a browser, media player, or other program. RABBIT downloads the latest build and installs app2clap.clap into your per-user CLAP folder, so no administrator rights are needed. Windows only. Standard REAPER installations only: it installs outside any portable REAPER folder.
 package-langpack-es-description = Translates REAPER's own interface into Spanish, including the SWS extension. Maintained by Javier Robledo for the Spanish REAPER community, and distributed through reaperespa.com — RABBIT downloads the current version and installs it as es_ES.ReaperLangPack. OSARA reads that file name to choose its own Spanish translation. After installing, pick the language in REAPER's preferences (or let RABBIT set it for you).
 package-langpack-de-description = Translates REAPER's own interface into German, including the SWS extension. Maintained by MrData and published in the REAPER Stash — RABBIT downloads the current version and installs it as de_DE.ReaperLangPack. After installing, pick the language in REAPER's preferences (or let RABBIT set it for you).
+package-langpack-fr-description = Translates REAPER's own interface into French, including the SWS extension. Maintained by Lee Julien and Pierre-Marie Curt for ReaperAccessible, the French screen-reader community, and published in their ReaPack repository — RABBIT downloads the current version and installs it as fr_CA.ReaperLangPack. OSARA reads that file name to choose its own French translation, and its fr_CA one is nearly complete where its fr_FR one still leaves about a third of the messages in English; the pack itself is the same standard French either way. After installing, pick the language in REAPER's preferences (or let RABBIT set it for you).
 
 # $reason is one of the localized "wizard-package-row-unavailable-*" strings
 # explaining *why* the row is unavailable. Appended to the row's main summary
@@ -137,6 +139,8 @@ config-set-reaper-language-es-name = Set REAPER's language to Spanish
 config-set-reaper-language-es-description = Tells REAPER to use the Spanish language pack, by writing it into reaper.ini. Without this you would have to select the language yourself under Options, Preferences, General. Untick if you only want the file installed.
 config-set-reaper-language-de-name = Set REAPER's language to German
 config-set-reaper-language-de-description = Tells REAPER to use the German language pack, by writing it into reaper.ini. Without this you would have to select the language yourself under Options, Preferences, General. Untick if you only want the file installed.
+config-set-reaper-language-fr-name = Set REAPER's language to French
+config-set-reaper-language-fr-description = Tells REAPER to use the French language pack, by writing it into reaper.ini. Without this you would have to select the language yourself under Options, Preferences, General. Untick if you only want the file installed.
 
 wizard-reapack-ack-heading = ReaPack donation notice
 wizard-reapack-ack-body = ReaPack is free software released under the LGPL. Its author Christian Fillion accepts optional donations to support continued development. Christian also maintains the SWS extensions and has landed code specifically to improve compatibility with OSARA in the past. Any support you can send has been well earned.

--- a/locales/es-ES/rabbit.ftl
+++ b/locales/es-ES/rabbit.ftl
@@ -19,6 +19,7 @@ package-surge-xt = Surge XT
 package-app2clap = app2clap
 package-langpack-es = REAPER en español
 package-langpack-de = REAPER en alemán
+package-langpack-fr = REAPER en francés
 package-langpack-es-variant-rae = REAPER Accesible español (es_ES)
 package-langpack-es-variant-pma = Equipo PMA (es_MX)
 
@@ -33,6 +34,7 @@ package-surge-xt-description = Surge XT es un sintetizador híbrido gratuito y d
 package-app2clap-description = app2clap es un complemento CLAP para Windows que captura audio de otras aplicaciones y lo lleva a REAPER (o cualquier host CLAP) como un plug‑in que insertas en una pista — útil para grabar o procesar sonido desde un navegador, reproductor multimedia u otro programa. RABBIT descarga la última compilación e instala app2clap.clap en tu carpeta CLAP de usuario, por lo que no se requieren privilegios de administrador. Solo para Windows. Solo en instalaciones estándar de REAPER. se instala fuera de cualquier carpeta portátil de REAPER.
 package-langpack-es-description = Traduce la interfaz de REAPER al español, incluida la extensión SWS. Mantenido por Javier Robledo para la comunidad hispanohablante de REAPER y publicado en reaperespa.com: RABBIT descarga la versión actual y la instala como es_ES.ReaperLangPack. OSARA usa ese nombre de archivo para elegir su propia traducción al español. Después de instalarlo, selecciona el idioma en las preferencias de REAPER (o deja que RABBIT lo haga por ti).
 package-langpack-de-description = Traduce la interfaz de REAPER al alemán, incluida la extensión SWS. Mantenido por MrData y publicado en el Stash de REAPER: RABBIT descarga la versión actual y la instala como de_DE.ReaperLangPack. Después de instalarlo, selecciona el idioma en las preferencias de REAPER (o deja que RABBIT lo haga por ti).
+package-langpack-fr-description = Traduce la interfaz de REAPER al francés, incluida la extensión SWS. Mantenido por Lee Julien y Pierre-Marie Curt para ReaperAccessible, la comunidad francesa de usuarios de lectores de pantalla, y publicado en su repositorio de ReaPack: RABBIT descarga la versión actual y la instala como fr_CA.ReaperLangPack. OSARA lee ese nombre de archivo para elegir su propia traducción al francés: la fr_CA está casi completa, mientras que la fr_FR todavía deja alrededor de un tercio de los mensajes en inglés; el paquete en sí es el mismo francés estándar en ambos casos. Después de instalarlo, selecciona el idioma en las preferencias de REAPER (o deja que RABBIT lo haga por ti).
 
 # $reason is one of the localized "wizard-package-row-unavailable-*" strings
 # explaining *why* the row is unavailable. Appended to the row's main summary
@@ -137,6 +139,8 @@ config-set-reaper-language-es-name = Configurar REAPER en español
 config-set-reaper-language-es-description = Indica a REAPER que use el paquete de idioma español, escribiéndolo en reaper.ini. Sin esto tendrías que seleccionar el idioma manualmente en Opciones, Preferencias, General. Desmarca esta casilla si solo quieres que se instale el archivo.
 config-set-reaper-language-de-name = Configurar REAPER en alemán
 config-set-reaper-language-de-description = Indica a REAPER que use el paquete de idioma alemán, escribiéndolo en reaper.ini. Sin esto tendrías que seleccionar el idioma manualmente en Opciones, Preferencias, General. Desmarca esta casilla si solo quieres que se instale el archivo.
+config-set-reaper-language-fr-name = Establecer el idioma de REAPER en francés
+config-set-reaper-language-fr-description = Indica a REAPER que use el paquete de idioma francés, escribiéndolo en reaper.ini. Sin esto tendrías que seleccionar el idioma manualmente en Opciones, Preferencias, General. Desmarca esta casilla si solo quieres que se instale el archivo.
 
 wizard-reapack-ack-heading = Anuncio de donaciones para ReaPack
 wizard-reapack-ack-body = ReaPack es software gratuito publicado bajo la licencia LGPL. Su autor, Christian Fillion, acepta donaciones opcionales para apoyar el desarrollo continuo. Christian también mantiene las extensiones SWS y en el pasado ha incorporado código específicamente para mejorar la compatibilidad con OSARA. Cualquier apoyo que puedas brindar está más que justificado.

--- a/locales/fr-FR/rabbit.ftl
+++ b/locales/fr-FR/rabbit.ftl
@@ -19,6 +19,7 @@ package-surge-xt = Surge XT
 package-app2clap = app2clap
 package-langpack-es = REAPER en espagnol
 package-langpack-de = REAPER en allemand
+package-langpack-fr = REAPER en français
 package-langpack-es-variant-rae = REAPER Accesible español (es_ES)
 package-langpack-es-variant-pma = Équipe PMA (es_MX)
 
@@ -33,6 +34,7 @@ package-surge-xt-description = Surge XT est un synthétiseur hybride gratuit et 
 package-app2clap-description = app2clap est un plug-in CLAP pour Windows qui capture l'audio d'autres applications et l'amène dans REAPER (ou tout hôte CLAP) sous forme de plug-in à insérer sur une piste — pratique pour enregistrer ou traiter le son d'un navigateur, d'un lecteur multimédia ou d'un autre programme. RABBIT télécharge la dernière version et installe app2clap.clap dans votre dossier CLAP personnel, sans droits d'administrateur. Windows uniquement. Installations standard de REAPER uniquement : l'installation se fait en dehors de tout dossier REAPER portable.
 package-langpack-es-description = Traduit l'interface de REAPER en espagnol, y compris l'extension SWS. Maintenu par Javier Robledo pour la communauté hispanophone de REAPER et publié sur reaperespa.com — RABBIT télécharge la version actuelle et l'installe sous le nom es_ES.ReaperLangPack. OSARA se sert de ce nom de fichier pour choisir sa propre traduction espagnole. Après l'installation, sélectionnez la langue dans les préférences de REAPER (ou laissez RABBIT s'en charger).
 package-langpack-de-description = Traduit l'interface de REAPER en allemand, y compris l'extension SWS. Maintenu par MrData et publié dans le Stash de REAPER — RABBIT télécharge la version actuelle et l'installe sous le nom de_DE.ReaperLangPack. Après l'installation, sélectionnez la langue dans les préférences de REAPER (ou laissez RABBIT s'en charger).
+package-langpack-fr-description = Traduit l'interface de REAPER en français, y compris l'extension SWS. Maintenu par Lee Julien et Pierre-Marie Curt pour ReaperAccessible, la communauté francophone des utilisateurs de lecteurs d'écran, et publié dans leur dépôt ReaPack — RABBIT télécharge la version actuelle et l'installe sous le nom fr_CA.ReaperLangPack. OSARA lit ce nom de fichier pour choisir sa propre traduction française : sa traduction fr_CA est presque complète, là où sa traduction fr_FR laisse encore environ un tiers des messages en anglais ; le pack, lui, est le même français standard dans les deux cas. Après l'installation, sélectionnez la langue dans les préférences de REAPER (ou laissez RABBIT s'en charger).
 
 # $reason is one of the localized "wizard-package-row-unavailable-*" strings
 # explaining *why* the row is unavailable. Appended to the row's main summary
@@ -137,6 +139,8 @@ config-set-reaper-language-es-name = Définir la langue de REAPER sur l'espagnol
 config-set-reaper-language-es-description = Indique à REAPER d'utiliser le pack de langue espagnol, en l'inscrivant dans reaper.ini. Sans cela, vous devriez sélectionner la langue vous-même dans Options, Préférences, Général. Décochez si vous voulez seulement installer le fichier.
 config-set-reaper-language-de-name = Définir la langue de REAPER sur l'allemand
 config-set-reaper-language-de-description = Indique à REAPER d'utiliser le pack de langue allemand, en l'inscrivant dans reaper.ini. Sans cela, vous devriez sélectionner la langue vous-même dans Options, Préférences, Général. Décochez si vous voulez seulement installer le fichier.
+config-set-reaper-language-fr-name = Définir la langue de REAPER sur le français
+config-set-reaper-language-fr-description = Indique à REAPER d'utiliser le pack de langue français, en l'inscrivant dans reaper.ini. Sans cela, vous devriez sélectionner la langue vous-même dans Options, Préférences, Général. Décochez si vous voulez seulement installer le fichier.
 
 wizard-reapack-ack-heading = Avis de don ReaPack
 wizard-reapack-ack-body = ReaPack est un logiciel libre publié sous licence LGPL. Son auteur, Christian Fillion, accepte des dons facultatifs pour soutenir la poursuite du développement. Christian maintient également les extensions SWS et a, par le passé, intégré du code spécifiquement destiné à améliorer la compatibilité avec OSARA. Tout soutien que vous pourrez lui apporter est amplement mérité.

--- a/locales/it-IT/rabbit.ftl
+++ b/locales/it-IT/rabbit.ftl
@@ -19,6 +19,7 @@ package-surge-xt = Surge XT
 package-app2clap = app2clap
 package-langpack-es = REAPER in spagnolo
 package-langpack-de = REAPER in tedesco
+package-langpack-fr = REAPER in francese
 package-langpack-es-variant-rae = REAPER Accesible español (es_ES)
 package-langpack-es-variant-pma = Team PMA (es_MX)
 
@@ -33,6 +34,7 @@ package-surge-xt-description = Surge XT è un sintetizzatore ibrido gratuito e o
 package-app2clap-description = app2clap è un plug-in CLAP per Windows che cattura l'audio di altre applicazioni e lo porta in REAPER (o in qualsiasi host CLAP) come plug-in da inserire su una traccia — utile per registrare o elaborare il suono di un browser, un lettore multimediale o un altro programma. RABBIT scarica la versione più recente e installa app2clap.clap nella tua cartella CLAP personale, senza bisogno dei diritti di amministratore. Solo Windows. Solo installazioni standard di REAPER: viene installato al di fuori di qualsiasi cartella REAPER portatile.
 package-langpack-es-description = Traduce l'interfaccia di REAPER in spagnolo, inclusa l'estensione SWS. Curato da Javier Robledo per la comunità ispanofona di REAPER e pubblicato su reaperespa.com: RABBIT scarica la versione attuale e la installa come es_ES.ReaperLangPack. OSARA usa quel nome di file per scegliere la propria traduzione spagnola. Dopo l'installazione, seleziona la lingua nelle preferenze di REAPER (oppure lascia che sia RABBIT a farlo).
 package-langpack-de-description = Traduce l'interfaccia di REAPER in tedesco, inclusa l'estensione SWS. Curato da MrData e pubblicato nello Stash di REAPER: RABBIT scarica la versione attuale e la installa come de_DE.ReaperLangPack. Dopo l'installazione, seleziona la lingua nelle preferenze di REAPER (oppure lascia che sia RABBIT a farlo).
+package-langpack-fr-description = Traduce l'interfaccia di REAPER in francese, inclusa l'estensione SWS. Curato da Lee Julien e Pierre-Marie Curt per ReaperAccessible, la comunità francese degli utenti di screen reader, e pubblicato nel loro repository ReaPack: RABBIT scarica la versione attuale e la installa come fr_CA.ReaperLangPack. OSARA legge quel nome di file per scegliere la propria traduzione francese: quella fr_CA è quasi completa, mentre quella fr_FR lascia ancora circa un terzo dei messaggi in inglese; il pacchetto in sé è lo stesso francese standard in entrambi i casi. Dopo l'installazione, seleziona la lingua nelle preferenze di REAPER (oppure lascia che sia RABBIT a farlo).
 
 # $reason is one of the localized "wizard-package-row-unavailable-*" strings
 # explaining *why* the row is unavailable. Appended to the row's main summary
@@ -137,6 +139,8 @@ config-set-reaper-language-es-name = Imposta la lingua di REAPER su spagnolo
 config-set-reaper-language-es-description = Indica a REAPER di usare il pacchetto lingua spagnolo, scrivendolo in reaper.ini. Senza questo dovresti selezionare la lingua manualmente in Opzioni, Preferenze, Generale. Deseleziona se vuoi solo installare il file.
 config-set-reaper-language-de-name = Imposta la lingua di REAPER su tedesco
 config-set-reaper-language-de-description = Indica a REAPER di usare il pacchetto lingua tedesco, scrivendolo in reaper.ini. Senza questo dovresti selezionare la lingua manualmente in Opzioni, Preferenze, Generale. Deseleziona se vuoi solo installare il file.
+config-set-reaper-language-fr-name = Imposta la lingua di REAPER sul francese
+config-set-reaper-language-fr-description = Indica a REAPER di usare il pacchetto lingua francese, scrivendolo in reaper.ini. Senza questo dovresti selezionare la lingua manualmente in Opzioni, Preferenze, Generale. Deseleziona se vuoi solo installare il file.
 
 wizard-reapack-ack-heading = Avviso di donazione ReaPack
 wizard-reapack-ack-body = ReaPack è software libero rilasciato sotto licenza LGPL. Il suo autore, Christian Fillion, accetta donazioni facoltative per sostenere lo sviluppo continuo. Christian gestisce anche le estensioni SWS e in passato ha integrato codice specificamente pensato per migliorare la compatibilità con OSARA. Qualsiasi sostegno tu possa offrirgli è ampiamente meritato.


### PR DESCRIPTION
## What

Adds ReaperAccessible's French language pack as a third REAPER language pack, next to the Spanish and German ones. Like those two, it translates REAPER's own interface **and** the SWS extension.

- Source: [reaperaccessible/rap_fr](https://github.com/reaperaccessible/rap_fr) (`LangPack/REAPER_SWS_FRC.ReaperLangPack`), the ReaPack repository of [ReaperAccessible](https://reaperaccessible.fr/), the French screen-reader community. Maintained by Lee Julien and Pierre-Marie Curt; currently at 7.75.1, published 2026-06-29 and updated regularly.
- One new manifest file, `102-langpack-fr.json`, plus the Fluent keys in all five locales, the package-count assertion, README and CHANGELOG. No other Rust changes — `build.rs` picks the manifest up, and both the "Language packs" wizard group and the "set REAPER's language" configuration step are generated from it.

## Why `fr_CA.ReaperLangPack`

The pack installs as `fr_CA.ReaperLangPack`, which looks odd for a pack written in standard French, so it is worth explaining.

OSARA picks its own translation from the language pack's file name ([`REAPER_LANG_TO_CODE`](https://github.com/jcsteh/osara/blob/master/src/translation.cpp)), and the two French translations OSARA ships are in very different shape:

| Installed name | OSARA loads | Untranslated strings |
| --- | --- | --- |
| `fr_CA.ReaperLangPack` | `fr_CA.po` | 5 of 898 |
| `fr_FR.ReaperLangPack` | `fr_FR.po` | 271 of 898 |

Leaving a third of OSARA's messages in English is a much worse experience for someone listening through a French voice than the handful of Canadian turns of phrase in `fr_CA` (*muté*, *soloté*). The pack itself is the same standard French under either name — only OSARA's own strings differ. Upstream's own file name, `REAPER_SWS_FRC`, is the one OSARA maps to `fr_CA` anyway, so this keeps the behaviour it was published with while satisfying the manifest invariant that `install_as` starts with the pack's locale prefix.

Happy to switch it to `fr_FR.ReaperLangPack`, or to add a variant dropdown like Spanish's, if you would rather offer the choice — the latter would mean generalizing `VARIANT_CHOICE_PACKAGE_ID`, which is currently hard-coded to `langpack-es`.

## Version rule

Unlike the Spanish and German packs, this one is published with a real version number, so it uses `VersionRule::Html` against the `desc` attribute of ReaperAccessible's ReaPack index rather than a content hash. The wizard shows `7.75.1` instead of a digest, and updates compare by ordering. The trade-off is a ~190 KB index fetch per version check where a content hash would do a HEAD request; happy to switch to `content_hash` + `exact` for consistency with the other two packs if you prefer.

## Testing

- `cargo fmt --all --check`, `cargo test -p rabbit-core` (321 passed).
- `rabbit latest --json` → `langpack-fr: 7.75.1`.
- `rabbit install-extension --package langpack-fr --apply` into a throwaway resource path: downloads 1,972,213 bytes and installs `LangPack/fr_CA.ReaperLangPack`.
- `rabbit setup --config-step set-reaper-language-fr --apply` writes `langpack=fr_CA.ReaperLangPack` into `reaper.ini`, leaving the rest of the file untouched.
- Installing the German pack afterwards removes the French file, confirming the exclusive group.
- `rabbit localize` resolves all four new keys in all five locales with no fallback.

The German, Spanish and Italian translations of the new strings are mine and would benefit from a native check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)