### PR TITLE
feat(ui): hide the package dropdowns that the current selection can't use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ from this file and posts it as the GitHub release body.
   the ReaPack ones — still name it, since there it is the truth.
   (Reported by Scott Chesworth from Q&A.)
 
+- The package list on the **Packages** page could go missing entirely
+  unless the window was maximized. The page had grown — the OSARA key-map
+  note, then the Spanish-variant and REAPER-language dropdowns — until the
+  controls stacked below the list no longer fitted the default window, and
+  the layout took the whole shortfall out of the only control allowed to
+  stretch: the list itself. It collapsed to nothing, and a control of zero
+  height is not exposed to screen readers at all, so VoiceOver, NVDA,
+  JAWS and Narrator alike found no list to read. The wizard pages now
+  scroll instead of clipping what does not fit, so every control keeps its
+  size whatever the window size and the language of the interface.
+
 ## [0.4.2] - 2026-08-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ from this file and posts it as the GitHub release body.
 
 ## [Unreleased]
 
+### Changed
+
+- The **REAPER language after installation** and **Spanish OSARA
+  translation** dropdowns on the Packages page now disappear while the
+  packages you ticked leave them nothing to decide, instead of staying on
+  the page greyed out — and, in the language one's case, greyed out and
+  empty. Tab already skipped both, but a screen reader reading the page
+  from top to bottom still stopped on them and announced a dead control.
+  They come back the moment you tick a package that gives them something
+  to choose.
+
 ### Fixed
 
 - The **Set REAPER's language** row no longer claims to require one

--- a/crates/rabbit-ui-wxdragon/src/wx_app.rs
+++ b/crates/rabbit-ui-wxdragon/src/wx_app.rs
@@ -2419,6 +2419,36 @@ pub fn run() {
     });
 }
 
+/// A wizard page: a scrolling panel rather than a plain one.
+///
+/// Every page stacks fixed-height controls — lists, detail panes, notes —
+/// and their total height grows with the UI language, since longer
+/// translations wrap the labels between them onto extra lines. A plain
+/// `wxPanel` cannot scroll, so whatever no longer fits is silently clipped,
+/// and a `BoxSizer` short of room takes the whole deficit out of its only
+/// proportion-1 child. On the Packages page that child is the package list
+/// itself: it collapsed to nothing on a window that wasn't maximized, and a
+/// control of zero height is not in the platform's accessibility tree at
+/// all, so screen readers stopped seeing the list. Scrolling keeps every
+/// control laid out at its real size and reachable whatever the window size.
+type WizardPage = ScrolledWindow;
+
+/// Vertical scroll step for a wizard page, in pixels. The horizontal step is
+/// 0, which turns horizontal scrolling off: page content expands to the page
+/// width instead of extending past it.
+const WIZARD_PAGE_SCROLL_STEP: i32 = 10;
+
+/// Build one empty wizard page inside the book.
+fn new_wizard_page(book: &SimpleBook) -> WizardPage {
+    let page = ScrolledWindow::builder(book).build();
+    page.set_scroll_rate(0, WIZARD_PAGE_SCROLL_STEP);
+    // wxScrolledWindow is created without wxTAB_TRAVERSAL, which wxPanel
+    // gets by default — without it Tab stops moving between the controls of
+    // a page. Put the flag back before any child is created.
+    page.set_style_raw(page.get_style_raw() | PanelStyle::TabTraversal.bits());
+    page
+}
+
 #[allow(clippy::too_many_arguments)] // UI plumbing: one parameter per widget handle.
 fn add_pages(
     book: &SimpleBook,
@@ -2430,11 +2460,11 @@ fn add_pages(
     self_update_status: StatusBar,
     language_footer: Panel,
 ) -> WizardWidgets {
-    let target_page = Panel::builder(book).build();
+    let target_page = new_wizard_page(book);
     let (target_choice, portable_folder, target_details) = build_target_page(&target_page, model);
     book.add_page(&target_page, &model.steps[TARGET_STEP].label, true, None);
 
-    let version_check_page = Panel::builder(book).build();
+    let version_check_page = new_wizard_page(book);
     let (
         version_check_status,
         version_check_gauge,
@@ -2452,7 +2482,7 @@ fn add_pages(
         None,
     );
 
-    let packages_page = Panel::builder(book).build();
+    let packages_page = new_wizard_page(book);
     let (
         package_checklist,
         package_details,
@@ -2475,7 +2505,7 @@ fn add_pages(
         None,
     );
 
-    let reapack_ack_page = Panel::builder(book).build();
+    let reapack_ack_page = new_wizard_page(book);
     let (_reapack_donate_link, reapack_ack_confirm) =
         build_reapack_ack_page(&reapack_ack_page, model);
     book.add_page(
@@ -2485,11 +2515,11 @@ fn add_pages(
         None,
     );
 
-    let review_page = Panel::builder(book).build();
+    let review_page = new_wizard_page(book);
     let review_text = build_review_page(&review_page, model);
     book.add_page(&review_page, &model.steps[REVIEW_STEP].label, false, None);
 
-    let progress_page = Panel::builder(book).build();
+    let progress_page = new_wizard_page(book);
     let (progress_status, progress_gauge, progress_details) =
         build_progress_page(&progress_page, model);
     book.add_page(
@@ -2499,7 +2529,7 @@ fn add_pages(
         None,
     );
 
-    let done_page = Panel::builder(book).build();
+    let done_page = new_wizard_page(book);
     let (done_status, done_details, done_launch_reaper, done_open_resource) =
         build_done_page(&done_page, model);
     book.add_page(&done_page, &model.steps[DONE_STEP].label, false, None);
@@ -2532,7 +2562,7 @@ fn add_pages(
     }
 }
 
-fn build_target_page(page: &Panel, model: &WizardModel) -> (Choice, TextCtrl, TextCtrl) {
+fn build_target_page(page: &WizardPage, model: &WizardModel) -> (Choice, TextCtrl, TextCtrl) {
     let sizer = BoxSizer::builder(Orientation::Vertical).build();
     add_heading(
         page,
@@ -3761,7 +3791,7 @@ fn relaunch_with_locale(locale: &str) {
 /// style after wx has created the control.
 #[cfg(target_os = "windows")]
 fn build_packages_page(
-    page: &Panel,
+    page: &WizardPage,
     model: &WizardModel,
     package_rows: Rc<RefCell<Vec<crate::PackageRow>>>,
     configuration_rows: Rc<RefCell<Vec<crate::ConfigurationRow>>>,
@@ -4858,7 +4888,7 @@ fn propagate_group_toggle_to_leaves(
 /// `set_value` callback owns all the toggle side effects.
 #[cfg(not(target_os = "windows"))]
 fn build_packages_page(
-    page: &Panel,
+    page: &WizardPage,
     model: &WizardModel,
     package_rows: Rc<RefCell<Vec<crate::PackageRow>>>,
     configuration_rows: Rc<RefCell<Vec<crate::ConfigurationRow>>>,
@@ -5762,7 +5792,7 @@ fn focus_packages_list_top(widgets: &WizardWidgets, _package_items: &PackagesSta
 }
 
 fn build_version_check_page(
-    page: &Panel,
+    page: &WizardPage,
     model: &WizardModel,
     package_count: i32,
 ) -> (StaticText, Gauge, StaticText, TextCtrl) {
@@ -5820,7 +5850,7 @@ fn build_version_check_page(
 /// transition routes through it conditionally. The Continue button stays
 /// disabled until the user checks the acknowledgement; that gating happens
 /// in `update_navigation` based on `reapack_ack_confirm.get_value()`.
-fn build_reapack_ack_page(page: &Panel, model: &WizardModel) -> (Button, CheckBox) {
+fn build_reapack_ack_page(page: &WizardPage, model: &WizardModel) -> (Button, CheckBox) {
     let sizer = BoxSizer::builder(Orientation::Vertical).build();
     add_heading(
         page,
@@ -5892,7 +5922,7 @@ fn open_external_url(url: &str) -> std::io::Result<()> {
     }
 }
 
-fn build_review_page(page: &Panel, model: &WizardModel) -> TextCtrl {
+fn build_review_page(page: &WizardPage, model: &WizardModel) -> TextCtrl {
     let sizer = BoxSizer::builder(Orientation::Vertical).build();
     add_heading(
         page,
@@ -5910,7 +5940,7 @@ fn build_review_page(page: &Panel, model: &WizardModel) -> TextCtrl {
     review
 }
 
-fn build_progress_page(page: &Panel, model: &WizardModel) -> (StaticText, Gauge, TextCtrl) {
+fn build_progress_page(page: &WizardPage, model: &WizardModel) -> (StaticText, Gauge, TextCtrl) {
     let sizer = BoxSizer::builder(Orientation::Vertical).build();
     add_heading(
         page,
@@ -5944,7 +5974,7 @@ fn build_progress_page(page: &Panel, model: &WizardModel) -> (StaticText, Gauge,
     (status, gauge, details)
 }
 
-fn build_done_page(page: &Panel, model: &WizardModel) -> (TextCtrl, TextCtrl, Button, Button) {
+fn build_done_page(page: &WizardPage, model: &WizardModel) -> (TextCtrl, TextCtrl, Button, Button) {
     let sizer = BoxSizer::builder(Orientation::Vertical).build();
     add_heading(
         page,
@@ -6029,13 +6059,13 @@ fn build_done_page(page: &Panel, model: &WizardModel) -> (TextCtrl, TextCtrl, Bu
     (status, details, launch_reaper, open_resource)
 }
 
-fn add_heading(page: &Panel, sizer: &BoxSizer, label: &str, name: &str) {
+fn add_heading<W: WxWidget>(page: &W, sizer: &BoxSizer, label: &str, name: &str) {
     let heading = StaticText::builder(page).with_label(label).build();
     heading.set_name(name);
     sizer.add(&heading, 0, SizerFlag::All | SizerFlag::Expand, 6);
 }
 
-fn add_label(page: &Panel, sizer: &BoxSizer, label: &str, name: &str) {
+fn add_label<W: WxWidget>(page: &W, sizer: &BoxSizer, label: &str, name: &str) {
     let widget = StaticText::builder(page).with_label(label).build();
     widget.set_name(name);
     sizer.add(

--- a/crates/rabbit-ui-wxdragon/src/wx_app.rs
+++ b/crates/rabbit-ui-wxdragon/src/wx_app.rs
@@ -3909,7 +3909,7 @@ fn build_packages_page(
         page,
         &sizer,
         &model.text.packages_reaper_language_label,
-        "rabbit-reaper-language-label",
+        REAPER_LANGUAGE_LABEL_NAME,
     );
     let reaper_language_choice = Choice::builder(page).build();
     reaper_language_choice.set_name(&model.text.packages_reaper_language_label);
@@ -3928,7 +3928,7 @@ fn build_packages_page(
         page,
         &sizer,
         &model.text.packages_spanish_variant_label,
-        "rabbit-spanish-variant-label",
+        SPANISH_VARIANT_LABEL_NAME,
     );
     let spanish_variant_choice = Choice::builder(page).build();
     spanish_variant_choice.set_name(&model.text.packages_spanish_variant_label);
@@ -5039,7 +5039,7 @@ fn build_packages_page(
         page,
         &sizer,
         &model.text.packages_reaper_language_label,
-        "rabbit-reaper-language-label",
+        REAPER_LANGUAGE_LABEL_NAME,
     );
     let reaper_language_choice = Choice::builder(page).build();
     reaper_language_choice.set_name(&model.text.packages_reaper_language_label);
@@ -5058,7 +5058,7 @@ fn build_packages_page(
         page,
         &sizer,
         &model.text.packages_spanish_variant_label,
-        "rabbit-spanish-variant-label",
+        SPANISH_VARIANT_LABEL_NAME,
     );
     let spanish_variant_choice = Choice::builder(page).build();
     spanish_variant_choice.set_name(&model.text.packages_spanish_variant_label);
@@ -6269,6 +6269,7 @@ fn sync_reaper_language_widget(rows: &[crate::PackageRow], choice: &Choice) {
     }
     choice.enable(!packs.is_empty());
     choice.set_can_focus(!packs.is_empty());
+    set_optional_choice_shown(choice, REAPER_LANGUAGE_LABEL_NAME, !packs.is_empty());
 }
 
 fn sync_spanish_variant_widget(rows: &[crate::PackageRow], choice: &Choice) {
@@ -6276,6 +6277,39 @@ fn sync_spanish_variant_widget(rows: &[crate::PackageRow], choice: &Choice) {
     let selected = crate::variant_choice_package_selected(rows, &selected_indices);
     choice.enable(selected);
     choice.set_can_focus(selected);
+    set_optional_choice_shown(choice, SPANISH_VARIANT_LABEL_NAME, selected);
+}
+
+/// wxWindow names of the labels sitting above the two Packages-page
+/// dropdowns that only apply to some selections. `set_optional_choice_shown`
+/// looks a label up by name from the dropdown's parent page, which keeps the
+/// dozen call sites that already carry a dropdown handle unchanged.
+const REAPER_LANGUAGE_LABEL_NAME: &str = "rabbit-reaper-language-label";
+const SPANISH_VARIANT_LABEL_NAME: &str = "rabbit-spanish-variant-label";
+
+/// Show or hide a dropdown together with its label, then re-lay out the page
+/// so the row's space is reclaimed (or given back).
+///
+/// A dropdown that doesn't apply to the current selection used to stay on
+/// the page, greyed out and — for the REAPER language — empty. Tab already
+/// skipped it, but a screen reader walking the page still stopped on a dead
+/// control and read out an empty combo box; hiding it removes it from the
+/// accessibility tree entirely, and it comes straight back when ticking a
+/// package makes the choice mean something again.
+fn set_optional_choice_shown(choice: &Choice, label_name: &str, shown: bool) {
+    if choice.is_shown() == shown {
+        return;
+    }
+    choice.show(shown);
+    let Some(page) = choice.get_parent() else {
+        return;
+    };
+    if let Some(label) = page.find_window_by_name(label_name) {
+        label.show(shown);
+    }
+    // The sizer reads each child's visibility when it lays the page out, so
+    // the hidden row only stops taking vertical space once we ask for it.
+    page.layout();
 }
 
 fn sync_osara_keymap_widgets(


### PR DESCRIPTION
Stacked on #23 — that branch is its base, so this PR shows both commits until the other one lands. Only the second commit belongs to this change.

The **Packages** page carries two dropdowns that apply to some package selections only: the REAPER language after installation, and which of the two Spanish OSARA translations to install. Until now they stayed on the page when they did not apply, disabled and unfocusable — and the language one also empty, since it lists the packs currently ticked. Tab skipped them, but a screen reader reading the page from top to bottom still stopped on each one and announced a dead control.

**The change:** hide the dropdown together with its label and lay the page out again so the row gives its space back; both reappear as soon as a ticked package gives them something to decide. The label is found by the `wxWindow` name it already carries, which keeps the dozen call sites that thread the dropdown handles through the tree callbacks untouched.

This is a taste call, deliberately kept separate from #23 so it can be dropped on its own: it does break the page's convention of keeping an inactive control on screen and explaining it, the way the OSARA key-map note does. Happy to close this one if you would rather keep the greyed-out dropdowns.

**Testing:** validated on the CI macOS build with VoiceOver — the dropdowns and their labels appear and disappear as packages are ticked, and the page keeps its layout. Untested on Windows (I have no Windows machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
