### PR TITLE
fix(ui): stop the close button abandoning a running install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,26 @@ from this file and posts it as the GitHub release body.
 
 ## [Unreleased]
 
+### Changed
+
+- Closing the wizard while an install is running now stops the run instead of
+  killing it. RABBIT asks first ("Stop the installation?", with **No** as the
+  focused button so a stray Enter can't end a running install), then finishes
+  the step it is on, releases everything it was holding, writes the report, and
+  closes. Before this, the close button tore the process down wherever the
+  worker happened to be — mid-download, mid-extract, or between a vendor
+  installer finishing and RABBIT recording it. Nothing unwound, so the install
+  lock file, the extraction temp folders and any part-downloaded files were
+  left behind, and the user got no record of what had actually landed.
+  The result page now has a third outcome next to "finished" and "finished with
+  errors": a stopped run lists which packages installed and which RABBIT never
+  reached, and does not report either as a failure. All five interface
+  languages carry the new wording.
+- Closing the wizard while RABBIT is updating itself is refused rather than
+  obeyed. Replacing RABBIT's own program files has no safe interruption point,
+  so RABBIT explains that and waits instead of leaving a half-swapped
+  executable behind.
+
 ### Fixed
 
 - The **Set REAPER's language** row no longer claims to require one

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1062,6 +1062,18 @@ Extension files:
   requires it.
 - Do not delete unknown files during update. Only remove files listed in a RABBIT
   receipt or explicitly owned by the package manifest.
+- Closing the window during an install stops the run; it does not abandon it.
+  Ask first, with **No** as the focused button, then let the pipeline stop at
+  its next package boundary so every guard unwinds the way it does on a clean
+  finish: the install lock is released, extraction temp dirs are removed, and
+  the run writes a report saying which packages landed and which were never
+  reached. Whatever step is running when the user confirms runs to completion
+  — an elevated vendor installer has no halfway point to return to — so the
+  wizard says it is finishing that step rather than pretending the stop is
+  instant.
+- Refuse to close at all while RABBIT is replacing its own program files.
+  That swap has no unwind path, so there is no answer that makes quitting
+  safe; say so instead of offering a choice that cannot be honoured.
 
 ## Localization
 

--- a/crates/rabbit-core/src/artifact.rs
+++ b/crates/rabbit-core/src/artifact.rs
@@ -3,13 +3,13 @@ use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::cancel::CancelToken;
 use crate::error::{IoPathContext, RabbitError, Result};
 use crate::hash::sha256_file;
 use crate::hfs::{fetch_file_list, file_url as hfs_file_url};
@@ -419,7 +419,12 @@ pub fn download_artifacts(
     artifacts: &[ArtifactDescriptor],
     cache_dir: &Path,
 ) -> Result<Vec<CachedArtifact>> {
-    download_artifacts_with_progress(artifacts, cache_dir, &ProgressReporter::noop())
+    download_artifacts_with_progress(
+        artifacts,
+        cache_dir,
+        &ProgressReporter::noop(),
+        &CancelToken::new(),
+    )
 }
 
 /// Like [`download_artifacts`] but emits per-artifact and per-chunk
@@ -431,12 +436,18 @@ pub fn download_artifacts(
 /// ([`DOWNLOAD_POOL_CONCURRENCY`] workers); results are returned in input
 /// order and the first failing artifact (in input order) aborts the batch,
 /// cancelling the remaining downloads.
+///
+/// `cancel` stops the batch the same way, at each worker's next chunk or
+/// retry checkpoint. A cancelled download reports
+/// [`RabbitError::DownloadInterrupted`]; the caller decides whether that
+/// reads as a failure or as "the user asked us to stop".
 pub fn download_artifacts_with_progress(
     artifacts: &[ArtifactDescriptor],
     cache_dir: &Path,
     progress: &ProgressReporter,
+    cancel: &CancelToken,
 ) -> Result<Vec<CachedArtifact>> {
-    let (pool, handles) = spawn_download_pool(artifacts, cache_dir, progress);
+    let (pool, handles) = spawn_download_pool(artifacts, cache_dir, progress, cancel);
     let mut cached = Vec::with_capacity(handles.len());
     for handle in handles {
         match handle.wait() {
@@ -487,12 +498,12 @@ impl DownloadHandle {
 ///
 /// [`cancel`]: DownloadPool::cancel
 pub(crate) struct DownloadPool {
-    cancel: Arc<AtomicBool>,
+    cancel: CancelToken,
 }
 
 impl DownloadPool {
     pub(crate) fn cancel(&self) {
-        self.cancel.store(true, Ordering::Relaxed);
+        self.cancel.cancel();
     }
 }
 
@@ -518,10 +529,14 @@ pub(crate) fn spawn_download_pool(
     artifacts: &[ArtifactDescriptor],
     cache_dir: &Path,
     progress: &ProgressReporter,
+    cancel: &CancelToken,
 ) -> (DownloadPool, Vec<DownloadHandle>) {
     type ResultSender = std::sync::mpsc::SyncSender<Result<CachedArtifact>>;
 
-    let cancel = Arc::new(AtomicBool::new(false));
+    // A child of the caller's token: the pool stops when the caller cancels
+    // the whole operation, and the batch can also stop its own workers on a
+    // failed artifact without cancelling anything above it.
+    let cancel = cancel.child();
     let mut queue: std::collections::VecDeque<(ArtifactDescriptor, Vec<ResultSender>)> =
         std::collections::VecDeque::with_capacity(artifacts.len());
     let mut job_index_by_target: std::collections::HashMap<(String, String, String), usize> =
@@ -552,7 +567,7 @@ pub(crate) fn spawn_download_pool(
     let worker_count = DOWNLOAD_POOL_CONCURRENCY.min(job_count);
     for _ in 0..worker_count {
         let queue = Arc::clone(&queue);
-        let cancel = Arc::clone(&cancel);
+        let cancel = cancel.clone();
         let cache_dir = cache_dir.to_path_buf();
         let progress = progress.clone();
         std::thread::spawn(move || {
@@ -561,7 +576,7 @@ pub(crate) fn spawn_download_pool(
             // per job (it is practically impossible and not clonable).
             let client = download_http_client();
             loop {
-                if cancel.load(Ordering::Relaxed) {
+                if cancel.is_cancelled() {
                     return;
                 }
                 let job = queue.lock().ok().and_then(|mut queue| queue.pop_front());
@@ -613,7 +628,7 @@ fn download_artifact(
     artifact: &ArtifactDescriptor,
     cache_dir: &Path,
     progress: &ProgressReporter,
-    cancel: &AtomicBool,
+    cancel: &CancelToken,
 ) -> Result<CachedArtifact> {
     let package_dir = cache_dir
         .join(&artifact.package_id)
@@ -694,7 +709,7 @@ fn fetch_remote_artifact_with_retries(
     package_id: &str,
     progress: &ProgressReporter,
     retry_delays: &[Duration],
-    cancel: &AtomicBool,
+    cancel: &CancelToken,
 ) -> Result<()> {
     let mut bytes_downloaded: u64 = 0;
     let mut bytes_total: Option<u64> = None;
@@ -707,7 +722,7 @@ fn fetch_remote_artifact_with_retries(
     let mut max_bytes_downloaded: u64 = 0;
 
     for attempt in 0..DOWNLOAD_MAX_ATTEMPTS {
-        if cancel.load(Ordering::Relaxed) {
+        if cancel.is_cancelled() {
             return Err(RabbitError::DownloadInterrupted {
                 url: url.to_string(),
                 bytes_downloaded: max_bytes_downloaded,
@@ -932,14 +947,14 @@ fn stream_response_to_file(
     bytes_downloaded: &mut u64,
     bytes_total: Option<u64>,
     progress: &ProgressReporter,
-    cancel: &AtomicBool,
+    cancel: &CancelToken,
 ) -> std::result::Result<(), StreamCopyError> {
     let mut buffer = vec![0u8; DOWNLOAD_CHUNK_SIZE];
     let mut bytes_at_last_event: u64 = *bytes_downloaded;
     let mut last_event_at = Instant::now();
 
     loop {
-        if cancel.load(Ordering::Relaxed) {
+        if cancel.is_cancelled() {
             return Err(StreamCopyError::Read(std::io::Error::new(
                 std::io::ErrorKind::Interrupted,
                 "the operation was cancelled",
@@ -1269,7 +1284,6 @@ pub(crate) fn download_url_with_retries(
     package_id: &str,
     progress: &ProgressReporter,
 ) -> Result<()> {
-    static NEVER_CANCELLED: AtomicBool = AtomicBool::new(false);
     fetch_remote_artifact_with_retries(
         &download_http_client()?,
         url,
@@ -1277,7 +1291,7 @@ pub(crate) fn download_url_with_retries(
         package_id,
         progress,
         &DOWNLOAD_RETRY_DELAYS,
-        &NEVER_CANCELLED,
+        &CancelToken::new(),
     )
 }
 
@@ -1562,7 +1576,6 @@ mod tests {
     }
 
     fn fetch_with_zero_delays(url: &str, part_path: &std::path::Path) -> Result<()> {
-        static NEVER_CANCELLED: AtomicBool = AtomicBool::new(false);
         fetch_remote_artifact_with_retries(
             &download_http_client().unwrap(),
             url,
@@ -1570,7 +1583,7 @@ mod tests {
             "test-package",
             &ProgressReporter::noop(),
             &[Duration::ZERO, Duration::ZERO, Duration::ZERO],
-            &NEVER_CANCELLED,
+            &CancelToken::new(),
         )
     }
 
@@ -2211,8 +2224,12 @@ mod tests {
 
         let cache_dir = tempdir().unwrap();
         let started = std::time::Instant::now();
-        let (_pool, handles) =
-            spawn_download_pool(&[slow, fast], cache_dir.path(), &ProgressReporter::noop());
+        let (_pool, handles) = spawn_download_pool(
+            &[slow, fast],
+            cache_dir.path(),
+            &ProgressReporter::noop(),
+            &CancelToken::new(),
+        );
         let mut handles = handles.into_iter();
         let slow_handle = handles.next().unwrap();
         let fast_handle = handles.next().unwrap();
@@ -2256,6 +2273,7 @@ mod tests {
             &[artifact.clone(), artifact],
             cache_dir.path(),
             &ProgressReporter::noop(),
+            &CancelToken::new(),
         );
         for handle in handles {
             let cached = handle.wait().unwrap();

--- a/crates/rabbit-core/src/cancel.rs
+++ b/crates/rabbit-core/src/cancel.rs
@@ -1,0 +1,120 @@
+//! Cooperative cancellation for the install pipeline.
+//!
+//! The pipeline runs on a worker thread while the wizard keeps painting, so
+//! "stop what you are doing" has to travel the other way: from the UI thread
+//! into a run that is already several packages deep. Killing the thread (or
+//! the process, which is what closing the window used to do) is not an
+//! option — a half-copied `UserPlugins` DLL, a vendor installer mid-write, a
+//! lock file nobody released and a temp folder nobody removed are exactly
+//! the mess this type exists to avoid.
+//!
+//! So cancellation is cooperative and coarse. The pipeline reads the token
+//! at package boundaries, between configuration steps, and inside the
+//! download loop's chunk/retry checkpoints. Whatever step is running when
+//! the flag goes up runs to completion — an elevated vendor installer
+//! cannot be unwound halfway, and a file copy that is already under way is
+//! safer finished than abandoned. Everything after it is recorded as
+//! cancelled and skipped, the operation returns its report through the
+//! normal path, and every `Drop` along the way (the install lock, the
+//! extraction temp dirs) runs as it would on a clean finish.
+//!
+//! The token is `Send + Sync` and cheap to clone: the UI holds one, hands a
+//! clone to the worker, and flips it from the close handler.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A shared "please stop" flag. Clones observe the same flag, so cancelling
+/// any clone cancels them all.
+///
+/// A token created with [`CancelToken::new`] and never cancelled is the
+/// no-op case, which is what the non-interactive entry points (the CLI,
+/// tests) pass so they don't have to care.
+#[derive(Clone, Default)]
+pub struct CancelToken {
+    flag: Arc<AtomicBool>,
+    /// Set for tokens made by [`CancelToken::child`]: the child is
+    /// cancelled when its parent is, but not the other way around.
+    parent: Option<Arc<CancelToken>>,
+}
+
+impl CancelToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Ask everything watching this token to stop at its next checkpoint.
+    pub fn cancel(&self) {
+        self.flag.store(true, Ordering::Relaxed);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.flag.load(Ordering::Relaxed)
+            || self
+                .parent
+                .as_ref()
+                .is_some_and(|parent| parent.is_cancelled())
+    }
+
+    /// A token that stops when `self` stops, plus whenever it is cancelled
+    /// on its own. Cancelling the child leaves the parent alone.
+    ///
+    /// The download pool uses this: it cancels its own workers when the
+    /// batch bails on a failed artifact, without telling the caller's token
+    /// that the whole operation was cancelled.
+    pub fn child(&self) -> Self {
+        Self {
+            flag: Arc::new(AtomicBool::new(false)),
+            parent: Some(Arc::new(self.clone())),
+        }
+    }
+}
+
+impl std::fmt::Debug for CancelToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CancelToken")
+            .field("cancelled", &self.is_cancelled())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fresh_token_is_not_cancelled() {
+        assert!(!CancelToken::new().is_cancelled());
+    }
+
+    #[test]
+    fn clones_share_one_flag() {
+        let token = CancelToken::new();
+        let clone = token.clone();
+
+        token.cancel();
+
+        assert!(clone.is_cancelled());
+    }
+
+    #[test]
+    fn a_child_follows_its_parent() {
+        let parent = CancelToken::new();
+        let child = parent.child();
+
+        parent.cancel();
+
+        assert!(child.is_cancelled());
+    }
+
+    #[test]
+    fn a_cancelled_child_leaves_its_parent_alone() {
+        let parent = CancelToken::new();
+        let child = parent.child();
+
+        child.cancel();
+
+        assert!(child.is_cancelled());
+        assert!(!parent.is_cancelled());
+    }
+}

--- a/crates/rabbit-core/src/configuration.rs
+++ b/crates/rabbit-core/src/configuration.rs
@@ -172,6 +172,8 @@ pub enum ConfigurationMessage {
     Skipped { step_id: String },
     /// None of the step's `requires_packages` was satisfied.
     SkippedDependencyMissing { step_id: String, dep_id: String },
+    /// The user stopped the run before this step was reached.
+    Cancelled { step_id: String },
     /// Generic "applied with no observable change" fallback used by
     /// [`skipped_step_report`] when called with `Applied`.
     #[default]
@@ -193,6 +195,9 @@ pub enum ConfigurationStatus {
     /// `dry_run` was set; we didn't write anything but report what
     /// would have happened.
     DryRun,
+    /// The user stopped the run before this step was reached. The step was
+    /// selected and its dependency was satisfied; it simply never ran.
+    Cancelled,
 }
 
 /// All configuration steps RABBIT knows how to run. Hardcoded today;
@@ -509,6 +514,15 @@ pub fn skipped_step_report(
         ConfigurationStatus::Applied => (
             format!("Configuration step {:?} applied without changes.", step.id),
             ConfigurationMessage::AppliedNoOp,
+        ),
+        ConfigurationStatus::Cancelled => (
+            format!(
+                "Configuration step {:?} did not run: you stopped the setup first.",
+                step.id
+            ),
+            ConfigurationMessage::Cancelled {
+                step_id: step.id.clone(),
+            },
         ),
         ConfigurationStatus::DryRun => dry_run_message_for(step),
     };

--- a/crates/rabbit-core/src/lib.rs
+++ b/crates/rabbit-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod antivirus;
 pub mod arch_probe;
 pub mod archive;
 pub mod artifact;
+pub mod cancel;
 pub mod configuration;
 pub mod detection;
 pub mod disk_image;

--- a/crates/rabbit-core/src/operation/mod.rs
+++ b/crates/rabbit-core/src/operation/mod.rs
@@ -15,6 +15,7 @@ use crate::artifact::{
     ArtifactDescriptor, ArtifactKind, CachedArtifact, DownloadHandle, expected_artifact_kind,
     resolve_latest_artifacts, spawn_download_pool,
 };
+use crate::cancel::CancelToken;
 use crate::detection::{
     default_standard_installation, detect_components, matching_user_plugin_files,
 };
@@ -93,6 +94,17 @@ impl PackageOperationReport {
                 PackageOperationStatus::Failed | PackageOperationStatus::SkippedDependencyFailed
             )
         })
+    }
+
+    /// True when the user stopped the run and at least one package was
+    /// left untouched because of it. Deliberately not folded into
+    /// [`Self::has_failures`]: a cancelled package installed nothing and
+    /// broke nothing, so calling it a failure would send the user hunting
+    /// for a problem that isn't there.
+    pub fn was_cancelled(&self) -> bool {
+        self.items
+            .iter()
+            .any(|item| matches!(item.status, PackageOperationStatus::Cancelled))
     }
 }
 
@@ -184,6 +196,8 @@ pub enum PackageOperationMessage {
     /// This package was skipped because `dependency` (a package it installs
     /// on top of, e.g. REAPER) failed or was skipped earlier in this run.
     SkippedDependencyFailed { dependency: String },
+    /// The user stopped the run before this package was reached.
+    Cancelled,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -278,6 +292,11 @@ pub enum PackageOperationStatus {
     /// This package was not attempted because a package it depends on
     /// (e.g. REAPER) failed or was itself skipped earlier in this run.
     SkippedDependencyFailed,
+    /// The user stopped the run before this package was reached. Nothing
+    /// was written for it, so the target is exactly as it was — which is
+    /// why this is not a failure: the report says "we never got here",
+    /// not "we tried and it broke".
+    Cancelled,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -395,13 +414,16 @@ pub fn execute_package_operation(
         cache_dir,
         options,
         &ProgressReporter::noop(),
+        &CancelToken::new(),
     )
 }
 
 /// Like [`execute_package_operation`] but threads a [`ProgressReporter`]
 /// down through the download and install phases so UIs can render a
-/// live progress bar. The no-op overload above keeps existing callers on
-/// the previous signature.
+/// live progress bar, and a [`CancelToken`] back up so they can stop the
+/// run. The no-op overload above keeps existing callers on the previous
+/// signature.
+#[allow(clippy::too_many_arguments)] // The pipeline's full-control entry point.
 pub fn execute_package_operation_with_progress(
     resource_path: &Path,
     package_ids: &[String],
@@ -410,6 +432,7 @@ pub fn execute_package_operation_with_progress(
     cache_dir: &Path,
     options: &PackageOperationOptions,
     progress: &ProgressReporter,
+    cancel: &CancelToken,
 ) -> Result<PackageOperationReport> {
     let artifacts = resolve_latest_artifacts(package_ids, platform, architecture)?;
     let detections = detect_components(resource_path, platform)?;
@@ -420,6 +443,7 @@ pub fn execute_package_operation_with_progress(
         cache_dir,
         options,
         progress,
+        cancel,
     )
 }
 
@@ -436,6 +460,7 @@ pub fn execute_resolved_package_operation(
         cache_dir,
         options,
         &ProgressReporter::noop(),
+        &CancelToken::new(),
     )
 }
 
@@ -446,6 +471,7 @@ pub fn execute_resolved_package_operation_with_progress(
     cache_dir: &Path,
     options: &PackageOperationOptions,
     progress: &ProgressReporter,
+    cancel: &CancelToken,
 ) -> Result<PackageOperationReport> {
     execute_resolved_package_operation_with_detections_and_progress(
         resource_path,
@@ -454,6 +480,7 @@ pub fn execute_resolved_package_operation_with_progress(
         cache_dir,
         options,
         progress,
+        cancel,
     )
 }
 
@@ -471,6 +498,7 @@ pub fn execute_resolved_package_operation_with_detections(
         cache_dir,
         options,
         &ProgressReporter::noop(),
+        &CancelToken::new(),
     )
 }
 
@@ -479,6 +507,15 @@ pub fn execute_resolved_package_operation_with_detections(
 /// boundary events as packages move through each phase; callers that
 /// don't care about the events use one of the wrappers above which
 /// pass a [`ProgressReporter::noop`] here.
+///
+/// `cancel` is read once per package, before that package's download is
+/// waited on. A package already installing keeps installing — a vendor
+/// installer cannot be unwound halfway — but nothing new starts, and every
+/// package the run never reached is recorded as
+/// [`PackageOperationStatus::Cancelled`] instead of silently vanishing
+/// from the report. The operation still returns `Ok`, so the install lock
+/// and the extraction temp dirs are released on the normal path and the
+/// caller gets a report saying exactly how far the run got.
 pub fn execute_resolved_package_operation_with_detections_and_progress(
     resource_path: &Path,
     artifacts: Vec<ArtifactDescriptor>,
@@ -486,6 +523,7 @@ pub fn execute_resolved_package_operation_with_detections_and_progress(
     cache_dir: &Path,
     options: &PackageOperationOptions,
     progress: &ProgressReporter,
+    cancel: &CancelToken,
 ) -> Result<PackageOperationReport> {
     ensure_resource_path_ready(resource_path, options.dry_run)?;
 
@@ -608,7 +646,7 @@ pub fn execute_resolved_package_operation_with_detections_and_progress(
     let (_download_pool, mut download_handles) = if download_jobs.is_empty() {
         (None, Vec::new())
     } else {
-        let (pool, handles) = spawn_download_pool(&download_jobs, cache_dir, progress);
+        let (pool, handles) = spawn_download_pool(&download_jobs, cache_dir, progress, cancel);
         (Some(pool), handles)
     };
     let mut handle_iter = download_handles.drain(..);
@@ -664,6 +702,18 @@ pub fn execute_resolved_package_operation_with_detections_and_progress(
         // downloaded or run.
         for (planned, handle) in unattended_installable.iter().zip(unattended_handles) {
             let package_id = planned.artifact.package_id.clone();
+            // Checked before the download is waited on, so a stop request
+            // that arrives while REAPER's installer is running takes effect
+            // the moment that installer returns rather than dragging the
+            // rest of the queue along behind it. Dropping `handle` unqueues
+            // this package's download.
+            if cancel.is_cancelled() {
+                items.push(cancelled_item(
+                    planned.artifact.clone(),
+                    planned.plan_action,
+                ));
+                continue;
+            }
             if let Some(dependency) = first_failed_dependency(&package_id, &failed) {
                 // Dropping `handle` here asks the pool to stop this
                 // package's (now pointless) download.
@@ -677,6 +727,17 @@ pub fn execute_resolved_package_operation_with_detections_and_progress(
             }
             let cached = match handle.wait() {
                 Ok(cached) => cached,
+                // A download aborted by the cancel reports as an interrupted
+                // transfer. Read the token before the error: "you stopped
+                // it" is the truth, and telling the user their connection
+                // dropped would send them debugging their network.
+                Err(_) if cancel.is_cancelled() => {
+                    items.push(cancelled_item(
+                        planned.artifact.clone(),
+                        planned.plan_action,
+                    ));
+                    continue;
+                }
                 Err(error) => {
                     items.push(failed_operation_item(
                         planned.artifact.clone(),
@@ -786,7 +847,7 @@ pub fn execute_resolved_package_operation_with_detections_and_progress(
     // queued last on the pool (lowest priority) and nothing installs them, so
     // waiting on them earlier would only delay the pipeline. The report is
     // sorted by package id at the end, so collection order is invisible.
-    let staged_deferred = if deferred_needs_download {
+    let staged_deferred = if deferred_needs_download && !cancel.is_cancelled() {
         let mut staged = Vec::with_capacity(deferred_handles.len());
         for handle in deferred_handles {
             // Deferred packages are only staged, never installed here, so a
@@ -849,6 +910,13 @@ pub fn execute_resolved_package_operation_with_detections_and_progress(
     let mut install_report: Option<InstallReport> = None;
     for (planned, handle) in direct_installable.iter().zip(direct_handles) {
         let package_id = planned.artifact.package_id.clone();
+        if cancel.is_cancelled() {
+            items.push(cancelled_item(
+                planned.artifact.clone(),
+                planned.plan_action,
+            ));
+            continue;
+        }
         if let Some(dependency) = first_failed_dependency(&package_id, &failed) {
             items.push(skipped_dependency_item(
                 planned.artifact.clone(),
@@ -860,6 +928,13 @@ pub fn execute_resolved_package_operation_with_detections_and_progress(
         }
         let cached = match handle.wait() {
             Ok(cached) => cached,
+            Err(_) if cancel.is_cancelled() => {
+                items.push(cancelled_item(
+                    planned.artifact.clone(),
+                    planned.plan_action,
+                ));
+                continue;
+            }
             Err(error) => {
                 items.push(failed_operation_item(
                     planned.artifact.clone(),
@@ -1175,6 +1250,30 @@ fn skipped_dependency_item(
         message_code: PackageOperationMessage::SkippedDependencyFailed {
             dependency: dependency.to_string(),
         },
+        artifact,
+        cached_artifact: None,
+        install_action: None,
+        backup_paths: Vec::new(),
+        backup_manifest_path: None,
+        planned_execution: None,
+        manual_instruction: None,
+    }
+}
+
+/// A package the run never reached because the user stopped it. Nothing was
+/// downloaded, nothing was written, and the package is left exactly as the
+/// run found it.
+fn cancelled_item(
+    artifact: ArtifactDescriptor,
+    plan_action: PlanActionKind,
+) -> PackageOperationItem {
+    PackageOperationItem {
+        package_id: artifact.package_id.clone(),
+        plan_action,
+        status: PackageOperationStatus::Cancelled,
+        message: "Not installed: you stopped the setup before RABBIT reached this package."
+            .to_string(),
+        message_code: PackageOperationMessage::Cancelled,
         artifact,
         cached_artifact: None,
         install_action: None,
@@ -2082,10 +2181,12 @@ mod tests {
         PackageAutomationSupport, PackageOperationMessage, PackageOperationOptions,
         PackageOperationStatus, PlannedArtifact, PlannedAutomationKind, PlannedExecutionKind,
         dependency_ordered, execute_resolved_package_operation,
-        execute_resolved_package_operation_with_detections, first_failed_dependency,
+        execute_resolved_package_operation_with_detections,
+        execute_resolved_package_operation_with_detections_and_progress, first_failed_dependency,
         plan_action_for_artifact,
     };
     use crate::artifact::{ArtifactDescriptor, ArtifactKind};
+    use crate::cancel::CancelToken;
     use crate::detection::detect_components;
     use crate::error::RabbitError;
     use crate::model::{Architecture, ComponentDetection, Confidence, Platform};
@@ -2094,6 +2195,7 @@ mod tests {
         PACKAGE_SWS,
     };
     use crate::plan::PlanActionKind;
+    use crate::progress::{ProgressEvent, ProgressReporter};
     use crate::receipt::{InstallState, load_install_state, save_install_state};
     use crate::version::Version;
     use std::collections::HashSet;
@@ -3607,6 +3709,171 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    /// The wizard's Close button cancels through this path, so a cancelled
+    /// run has to look like a run that stopped, not one that broke: no
+    /// package reports a failure, the report says what was skipped, and the
+    /// install lock is released the same way a clean finish releases it.
+    #[test]
+    fn a_cancelled_run_reports_every_untouched_package_and_releases_its_lock() {
+        let dir = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let lock_path = dir.path().join("install.lock");
+        let cancel = CancelToken::new();
+        cancel.cancel();
+
+        let report = execute_resolved_package_operation_with_detections_and_progress(
+            dir.path(),
+            vec![
+                artifact(
+                    PACKAGE_REAPACK,
+                    ArtifactKind::ExtensionBinary,
+                    "reaper_reapack-x64.dll",
+                ),
+                artifact(
+                    PACKAGE_REAKONTROL,
+                    ArtifactKind::ExtensionBinary,
+                    "reaper_reakontrol-x64.dll",
+                ),
+            ],
+            &[],
+            cache.path(),
+            &PackageOperationOptions {
+                dry_run: false,
+                allow_reaper_running: false,
+                stage_unsupported: false,
+                replace_osara_keymap: false,
+                target_app_path: None,
+                lock_path: Some(lock_path.clone()),
+                force_reinstall_packages: Vec::new(),
+                package_variants: Default::default(),
+            },
+            &ProgressReporter::noop(),
+            &cancel,
+        )
+        .unwrap();
+
+        assert_eq!(report.items.len(), 2);
+        for item in &report.items {
+            assert_eq!(
+                item.status,
+                PackageOperationStatus::Cancelled,
+                "{} should be cancelled",
+                item.package_id
+            );
+            assert_eq!(item.message_code, PackageOperationMessage::Cancelled);
+        }
+        // Stopping is not failing: the wizard picks its result heading from
+        // these two, and a cancelled run must not read as an error.
+        assert!(report.was_cancelled());
+        assert!(!report.has_failures());
+        // The artifacts point at URLs no test can reach, so any download
+        // that ran would have failed the run instead of cancelling it.
+        assert!(
+            report
+                .items
+                .iter()
+                .all(|item| item.cached_artifact.is_none())
+        );
+        // The lock guard unwound with the operation. Left behind, it would
+        // block the next run against this target.
+        assert!(!lock_path.exists());
+    }
+
+    /// Cancelling partway keeps what already landed and stops before the
+    /// next package. This is the case the close button actually produces:
+    /// the user stops during a multi-package run, and needs the report to
+    /// tell them which half of it happened.
+    #[test]
+    fn cancelling_partway_keeps_what_already_installed() {
+        let dir = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let first_source = dir.path().join("reaper_reapack-x64.dll");
+        fs::write(&first_source, b"reapack").unwrap();
+        let second_source = dir.path().join("reaper_reakontrol-x64.dll");
+        fs::write(&second_source, b"reakontrol").unwrap();
+        let resource_path = dir.path().join("PortableREAPER");
+        fs::create_dir_all(&resource_path).unwrap();
+
+        let cancel = CancelToken::new();
+        let cancel_on_first_install = cancel.clone();
+        // Installs run one at a time in input order, so cancelling when the
+        // first one completes lands squarely on the second's checkpoint.
+        let progress = ProgressReporter::new(move |event| {
+            if matches!(
+                event,
+                ProgressEvent::InstallCompleted { ref package_id } if package_id == PACKAGE_REAPACK
+            ) {
+                cancel_on_first_install.cancel();
+            }
+        });
+
+        let report = execute_resolved_package_operation_with_detections_and_progress(
+            &resource_path,
+            vec![
+                artifact_with_url(
+                    PACKAGE_REAPACK,
+                    ArtifactKind::ExtensionBinary,
+                    "reaper_reapack-x64.dll",
+                    &first_source.display().to_string(),
+                ),
+                artifact_with_url(
+                    PACKAGE_REAKONTROL,
+                    ArtifactKind::ExtensionBinary,
+                    "reaper_reakontrol-x64.dll",
+                    &second_source.display().to_string(),
+                ),
+            ],
+            &[],
+            cache.path(),
+            &PackageOperationOptions {
+                dry_run: false,
+                allow_reaper_running: false,
+                stage_unsupported: false,
+                replace_osara_keymap: false,
+                target_app_path: None,
+                lock_path: Some(dir.path().join("install.lock")),
+                force_reinstall_packages: Vec::new(),
+                package_variants: Default::default(),
+            },
+            &progress,
+            &cancel,
+        )
+        .unwrap();
+
+        let status_of = |package_id: &str| {
+            report
+                .items
+                .iter()
+                .find(|item| item.package_id == package_id)
+                .unwrap_or_else(|| panic!("{package_id} is missing from the report"))
+                .status
+        };
+        assert_eq!(
+            status_of(PACKAGE_REAPACK),
+            PackageOperationStatus::InstalledOrChecked
+        );
+        assert_eq!(
+            status_of(PACKAGE_REAKONTROL),
+            PackageOperationStatus::Cancelled
+        );
+        assert!(report.was_cancelled());
+        assert!(!report.has_failures());
+        // The half that landed really landed: a stop must not roll back
+        // work the user already waited through.
+        assert!(
+            resource_path
+                .join("UserPlugins")
+                .join("reaper_reapack-x64.dll")
+                .is_file()
+        );
+        assert!(
+            !resource_path
+                .join("UserPlugins")
+                .join("reaper_reakontrol-x64.dll")
+                .exists()
+        );
     }
 
     fn artifact(package_id: &str, kind: ArtifactKind, file_name: &str) -> ArtifactDescriptor {

--- a/crates/rabbit-core/src/setup.rs
+++ b/crates/rabbit-core/src/setup.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Result;
 use crate::artifact::ArtifactDescriptor;
+use crate::cancel::CancelToken;
 use crate::configuration::{
     ConfigurationStatus, ConfigurationStepReport, apply_configuration_step,
     builtin_configuration_steps, skipped_step_report,
@@ -67,6 +68,21 @@ pub struct SetupReport {
     pub configuration_steps: Vec<ConfigurationStepReport>,
 }
 
+impl SetupReport {
+    /// True when the user stopped the run and something was left undone
+    /// because of it. Drives the "stopped" wording on the wizard's result
+    /// page, which must not read as either success or failure.
+    pub fn was_cancelled(&self) -> bool {
+        self.package_operation.was_cancelled()
+            || self.configuration_steps.iter().any(|step| {
+                matches!(
+                    step.status,
+                    crate::configuration::ConfigurationStatus::Cancelled
+                )
+            })
+    }
+}
+
 pub fn setup_requires_extension_support(package_ids: &[String]) -> bool {
     package_ids
         .iter()
@@ -89,6 +105,7 @@ pub fn execute_setup_operation(
         cache_dir,
         options,
         &ProgressReporter::noop(),
+        &CancelToken::new(),
     )
 }
 
@@ -96,6 +113,7 @@ pub fn execute_setup_operation(
 /// through to the download, install, and configuration phases. Wired
 /// up by the wxdragon wizard to drive a live progress bar; the no-op
 /// overload above is what the CLI and tests use.
+#[allow(clippy::too_many_arguments)] // The pipeline's full-control entry point.
 pub fn execute_setup_operation_with_progress(
     resource_path: &Path,
     package_ids: &[String],
@@ -104,6 +122,7 @@ pub fn execute_setup_operation_with_progress(
     cache_dir: &Path,
     options: &SetupOptions,
     progress: &ProgressReporter,
+    cancel: &CancelToken,
 ) -> Result<SetupReport> {
     let resource_init = initialize_resource_path(
         resource_path,
@@ -133,6 +152,7 @@ pub fn execute_setup_operation_with_progress(
             package_variants: options.package_variants.clone(),
         },
         progress,
+        cancel,
     )?;
 
     let _ = architecture;
@@ -148,6 +168,7 @@ pub fn execute_setup_operation_with_progress(
         },
         options.dry_run,
         progress,
+        cancel,
     )?;
 
     Ok(SetupReport {
@@ -171,6 +192,7 @@ pub fn execute_resolved_setup_operation(
         cache_dir,
         options,
         &ProgressReporter::noop(),
+        &CancelToken::new(),
     )
 }
 
@@ -181,6 +203,7 @@ pub fn execute_resolved_setup_operation_with_progress(
     cache_dir: &Path,
     options: &SetupOptions,
     progress: &ProgressReporter,
+    cancel: &CancelToken,
 ) -> Result<SetupReport> {
     let resource_init = initialize_resource_path(
         resource_path,
@@ -212,6 +235,7 @@ pub fn execute_resolved_setup_operation_with_progress(
             package_variants: options.package_variants.clone(),
         },
         progress,
+        cancel,
     )?;
 
     // We don't have a platform/architecture handy on this code path
@@ -232,6 +256,7 @@ pub fn execute_resolved_setup_operation_with_progress(
         },
         options.dry_run,
         progress,
+        cancel,
     )?;
 
     Ok(SetupReport {
@@ -287,7 +312,9 @@ fn retain_packages_that_landed(
     for item in &report.items {
         if matches!(
             item.status,
-            PackageOperationStatus::Failed | PackageOperationStatus::SkippedDependencyFailed
+            PackageOperationStatus::Failed
+                | PackageOperationStatus::SkippedDependencyFailed
+                | PackageOperationStatus::Cancelled
         ) {
             installed_or_pending.remove(&item.package_id);
         }
@@ -301,6 +328,7 @@ fn run_configuration_steps(
     context: &crate::configuration::ConfigurationContext<'_>,
     dry_run: bool,
     progress: &ProgressReporter,
+    cancel: &CancelToken,
 ) -> Result<Vec<ConfigurationStepReport>> {
     let selected: BTreeSet<&str> = selected_ids.iter().map(String::as_str).collect();
     let steps = builtin_configuration_steps();
@@ -322,6 +350,13 @@ fn run_configuration_steps(
                 step,
                 ConfigurationStatus::SkippedDependencyMissing,
             ));
+            continue;
+        }
+        // Steps write into REAPER's own ini files, so the checkpoint sits
+        // before the step rather than inside it: a half-rewritten
+        // `reaper.ini` is worse than one the run never touched.
+        if cancel.is_cancelled() {
+            reports.push(skipped_step_report(step, ConfigurationStatus::Cancelled));
             continue;
         }
         progress.report(ProgressEvent::ConfigurationStarted {

--- a/crates/rabbit-ui-wxdragon/src/lib.rs
+++ b/crates/rabbit-ui-wxdragon/src/lib.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 
 use rabbit_core::arch_probe::probe_executable_architecture;
 use rabbit_core::artifact::{default_cache_dir, expected_artifact_kind};
+use rabbit_core::cancel::CancelToken;
 use rabbit_core::detection::{
     DiscoveryOptions, colocated_portable_root, default_standard_installation, detect_components,
     discover_installations,
@@ -161,6 +162,10 @@ pub struct WizardText {
     pub progress_heading: String,
     pub progress_status: String,
     pub progress_status_running: String,
+    /// Shown from the moment the user confirms the stop until the pipeline
+    /// finishes the step it is on. Deliberately not "cancelled": nothing has
+    /// stopped yet when it first appears.
+    pub progress_status_cancelling: String,
     pub progress_details_label: String,
     pub progress_details_idle: String,
     pub progress_details_starting: String,
@@ -170,6 +175,7 @@ pub struct WizardText {
     pub done_status_success: String,
     pub done_status_completed_with_errors: String,
     pub done_status_error: String,
+    pub done_status_cancelled: String,
     pub done_status_no_packages: String,
     pub done_show_details_label: String,
     pub done_launch_reaper_label: String,
@@ -181,6 +187,10 @@ pub struct WizardText {
     pub done_self_update_error_prefix: String,
     pub done_self_update_relaunch_prefix: String,
     pub self_update_status_checking: String,
+    pub close_during_install_title: String,
+    pub close_during_install_body: String,
+    pub close_during_self_update_title: String,
+    pub close_during_self_update_body: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -426,6 +436,11 @@ pub enum WizardOutcomeStatus {
     /// the done page shows "completed with errors".
     CompletedWithErrors,
     Error,
+    /// The user stopped the run. Some packages may have installed before
+    /// the stop; the ones after it were never touched. Distinct from both
+    /// `CompletedWithErrors` (nothing broke) and `Error` (the run did what
+    /// it was asked to do, right up to being asked to stop).
+    Cancelled,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -801,6 +816,7 @@ fn wizard_text(localizer: &Localizer) -> WizardText {
         done_heading: localizer.text("wizard-done-heading").value,
         done_status: localizer.text("wizard-done-status-idle").value,
         progress_status_running: localizer.text("wizard-progress-status-running").value,
+        progress_status_cancelling: localizer.text("wizard-progress-status-cancelling").value,
         progress_details_label: localizer.text("wizard-progress-details-label").value,
         progress_details_idle: localizer.text("wizard-progress-details-idle").value,
         progress_details_starting: localizer.text("wizard-progress-details-starting").value,
@@ -810,6 +826,7 @@ fn wizard_text(localizer: &Localizer) -> WizardText {
             .text("wizard-done-status-completed-with-errors")
             .value,
         done_status_error: localizer.text("wizard-done-status-error").value,
+        done_status_cancelled: localizer.text("wizard-done-status-cancelled").value,
         done_status_no_packages: localizer.text("wizard-done-status-no-packages").value,
         done_show_details_label: localizer.text("wizard-done-show-details").value,
         done_launch_reaper_label: localized_wx_mnemonic_label(
@@ -837,6 +854,12 @@ fn wizard_text(localizer: &Localizer) -> WizardText {
             .text("wizard-done-self-update-relaunch-prefix")
             .value,
         self_update_status_checking: localizer.text("wizard-self-update-status-checking").value,
+        close_during_install_title: localizer.text("wizard-close-during-install-title").value,
+        close_during_install_body: localizer.text("wizard-close-during-install-body").value,
+        close_during_self_update_title: localizer
+            .text("wizard-close-during-self-update-title")
+            .value,
+        close_during_self_update_body: localizer.text("wizard-close-during-self-update-body").value,
     }
 }
 
@@ -1825,7 +1848,11 @@ fn default_portable_reaper_app_path(platform: Platform, resource_path: &Path) ->
 }
 
 pub fn execute_wizard_install(request: WizardInstallRequest) -> Result<SetupReport> {
-    execute_wizard_install_with_progress(request, &rabbit_core::progress::ProgressReporter::noop())
+    execute_wizard_install_with_progress(
+        request,
+        &rabbit_core::progress::ProgressReporter::noop(),
+        &CancelToken::new(),
+    )
 }
 
 /// Like [`execute_wizard_install`] but threads a [`ProgressReporter`]
@@ -1833,11 +1860,15 @@ pub fn execute_wizard_install(request: WizardInstallRequest) -> Result<SetupRepo
 /// render a live status bar. The plain [`execute_wizard_install`]
 /// delegates here with a [`ProgressReporter::noop`].
 ///
+/// `cancel` travels the other way: the wizard flips it when the user asks
+/// to stop, and the pipeline reads it at each package boundary.
+///
 /// [`ProgressReporter`]: rabbit_core::progress::ProgressReporter
 /// [`ProgressReporter::noop`]: rabbit_core::progress::ProgressReporter::noop
 pub fn execute_wizard_install_with_progress(
     request: WizardInstallRequest,
     progress: &rabbit_core::progress::ProgressReporter,
+    cancel: &CancelToken,
 ) -> Result<SetupReport> {
     // Before any download, make Windows Defender ignore RABBIT's own cache
     // folder so a freshly built, low-prevalence (but signed) installer —
@@ -1879,6 +1910,7 @@ pub fn execute_wizard_install_with_progress(
             configuration_step_ids: request.configuration_step_ids.clone(),
         },
         progress,
+        cancel,
     )?;
 
     // Remember what the user decided about the packages that remember it,
@@ -2080,7 +2112,12 @@ pub fn wizard_outcome_report_from_success(
 ) -> WizardOutcomeReport {
     let summary = summarize_setup_report(model, report);
     WizardOutcomeReport {
-        status: if report.package_operation.has_failures() {
+        // Cancellation outranks a package failure in the heading: "you
+        // stopped it" explains the half-finished run, where "finished with
+        // errors" would send the user looking for a fault.
+        status: if report.was_cancelled() {
+            WizardOutcomeStatus::Cancelled
+        } else if report.package_operation.has_failures() {
             WizardOutcomeStatus::CompletedWithErrors
         } else {
             WizardOutcomeStatus::Success
@@ -2786,6 +2823,7 @@ fn status_label_for_summary(
             "status-skipped-dependency-failed",
             "Skipped (dependency failed)",
         ),
+        PackageOperationStatus::Cancelled => ("status-cancelled", "Not installed (you stopped)"),
     };
     localizer
         .map(|localizer| localizer.text(id).value)
@@ -2855,6 +2893,7 @@ fn localized_package_operation_message(
             "package-status-skipped-dependency-failed",
             &[("dependency", dependency.as_str())],
         ),
+        Msg::Cancelled => localizer.text("package-status-cancelled"),
     };
     if message.missing {
         fallback_english.to_string()
@@ -2941,6 +2980,7 @@ fn localized_configuration_message(
             &[("step", step_id.as_str()), ("dependency", dep_id.as_str())],
         ),
         Msg::AppliedNoOp => localizer.text("config-message-applied-no-op"),
+        Msg::Cancelled { .. } => localizer.text("config-message-cancelled"),
     };
     if message.missing {
         fallback_english.to_string()
@@ -2988,6 +3028,7 @@ fn configuration_status_label_for_summary(
             "Skipped (dependency missing)",
         ),
         ConfigurationStatus::DryRun => ("config-status-dry-run", "Dry run"),
+        ConfigurationStatus::Cancelled => ("config-status-cancelled", "Did not run (you stopped)"),
     };
     localizer
         .map(|localizer| localizer.text(id).value)

--- a/crates/rabbit-ui-wxdragon/src/wx_app.rs
+++ b/crates/rabbit-ui-wxdragon/src/wx_app.rs
@@ -5,9 +5,10 @@ use std::process::Command;
 use std::rc::Rc;
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
+use rabbit_core::cancel::CancelToken;
 use rabbit_core::localization::{Localizer, resolve_runtime_locale};
 use rabbit_core::self_update::SelfUpdateCheckReport;
 
@@ -174,6 +175,86 @@ const REVIEW_STEP: usize = 4;
 const PROGRESS_STEP: usize = 5;
 const DONE_STEP: usize = 6;
 
+/// Set while the self-update worker is swapping RABBIT's own files. That
+/// swap has no unwind path — the whole point of the progress window having
+/// no Cancel button — so the close handler refuses to quit under it rather
+/// than leaving a half-replaced executable behind. A plain static because
+/// `start_self_update_apply` is reachable from the startup prompt and from
+/// the Done page, neither of which shares the wizard's state.
+static SELF_UPDATE_APPLYING: AtomicBool = AtomicBool::new(false);
+
+/// The install worker's half of the close handshake.
+///
+/// Closing the window used to end the process wherever the worker happened
+/// to be: mid-download, mid-extract, or between a vendor installer finishing
+/// and RABBIT writing the receipt that records it. Nothing was cleaned up,
+/// because nothing unwound — no `Drop` ran, so the install lock file, the
+/// extraction temp dirs and any `.part` downloads stayed behind, and the
+/// user got no report of what had actually landed.
+///
+/// Now the close handler talks to the worker instead. It flips `cancel`,
+/// leaves `close_when_done` set, and vetoes the close; the pipeline stops at
+/// its next package boundary, unwinds normally, writes its report, and the
+/// completion closure closes the window for real.
+#[derive(Default)]
+struct InstallRunState {
+    /// The running install's token. `None` before the first install and
+    /// after each one finishes.
+    cancel: Mutex<Option<CancelToken>>,
+    /// True between the Install click and the worker's completion closure.
+    running: AtomicBool,
+    /// Set when the user asked to close during an install: the completion
+    /// closure closes the window once the worker is done.
+    close_when_done: AtomicBool,
+}
+
+impl InstallRunState {
+    fn begin(&self) -> CancelToken {
+        let token = CancelToken::new();
+        if let Ok(mut slot) = self.cancel.lock() {
+            *slot = Some(token.clone());
+        }
+        self.running.store(true, Ordering::SeqCst);
+        token
+    }
+
+    fn finish(&self) {
+        self.running.store(false, Ordering::SeqCst);
+        self.close_when_done.store(false, Ordering::SeqCst);
+        if let Ok(mut slot) = self.cancel.lock() {
+            *slot = None;
+        }
+    }
+
+    fn is_running(&self) -> bool {
+        self.running.load(Ordering::SeqCst)
+    }
+
+    /// Ask the pipeline to stop, and remember that the window should close
+    /// once it has. Returns `false` when there was nothing left to stop —
+    /// the run finished while the confirmation dialog was on screen, whose
+    /// nested event loop is what lets the worker's completion closure run
+    /// mid-question. Both halves happen under the one lock `finish` takes,
+    /// so the answer can't go stale between them.
+    fn request_stop_and_close(&self) -> bool {
+        let Ok(slot) = self.cancel.lock() else {
+            return false;
+        };
+        match slot.as_ref() {
+            Some(token) => {
+                self.close_when_done.store(true, Ordering::SeqCst);
+                token.cancel();
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn stop_requested(&self) -> bool {
+        self.close_when_done.load(Ordering::SeqCst)
+    }
+}
+
 #[derive(Default)]
 struct SelfUpdateUiState {
     /// Result of the one-shot manifest check at startup. `None` while the
@@ -192,6 +273,98 @@ struct SelfUpdateUiState {
     /// result (e.g., a step change that re-invokes render) skip the
     /// modal so the user isn't re-prompted after dismissing it.
     prompted: bool,
+}
+
+/// What closing the window should do right now.
+enum CloseVerdict {
+    /// Nothing is running: destroy the window.
+    Allow,
+    /// An install is running and the user has not been asked yet.
+    Ask,
+    /// An install is running and the user already said "stop": the worker
+    /// is unwinding and will close the window when it is done.
+    AlreadyStopping,
+    /// RABBIT is replacing its own files. There is no safe moment to quit.
+    SelfUpdateInProgress,
+}
+
+/// Say that RABBIT is stopping, in both places the progress page speaks
+/// from: the status heading and the running log.
+///
+/// The log is a `TextCtrl` and takes focus; the status heading is a
+/// `StaticText` and cannot, and a label change on its own is not something
+/// a screen reader announces. Moving focus onto the log is what makes the
+/// answer to "did it hear me?" audible.
+fn announce_stopping(widgets: &WizardWidgets, model: &WizardModel) {
+    widgets
+        .progress_status
+        .set_label(&model.text.progress_status_cancelling);
+    widgets
+        .progress_details
+        .append_text(&format!("\n{}", model.text.progress_status_cancelling));
+    widgets.progress_details.set_focus();
+}
+
+fn close_verdict(install_run: &InstallRunState) -> CloseVerdict {
+    if SELF_UPDATE_APPLYING.load(Ordering::SeqCst) {
+        return CloseVerdict::SelfUpdateInProgress;
+    }
+    if !install_run.is_running() {
+        return CloseVerdict::Allow;
+    }
+    if install_run.stop_requested() {
+        return CloseVerdict::AlreadyStopping;
+    }
+    CloseVerdict::Ask
+}
+
+/// Ask before throwing away a running install. Returns `true` when the user
+/// confirmed.
+///
+/// `wxNO_DEFAULT` puts the focused button on **No**: this dialog appears
+/// over work the user asked for, so a stray Enter or Space — from a screen
+/// reader user tabbing around the progress page, say — must not be what
+/// stops their REAPER install halfway. wxdragon's `MessageDialogStyle`
+/// doesn't name the flag, so it comes from the raw wx constant.
+fn confirm_stop_install(model: &WizardModel) -> bool {
+    let no_default = MessageDialogStyle::from_bits_retain(wxdragon::ffi::WXD_NO_DEFAULT);
+    let mut confirmed = false;
+    with_ui_frame(|frame| {
+        let dialog = MessageDialog::builder(
+            frame,
+            &model.text.close_during_install_body,
+            &model.text.close_during_install_title,
+        )
+        .with_style(
+            MessageDialogStyle::YesNo
+                | MessageDialogStyle::IconWarning
+                | MessageDialogStyle::Centre
+                | no_default,
+        )
+        .build();
+        confirmed = dialog.show_modal() == ID_YES;
+    });
+    confirmed
+}
+
+/// Tell the user why the window will not close during a self-update. There
+/// is no Yes/No here because there is no "yes": the file swap has no unwind
+/// path, so the only honest answer is "wait".
+fn show_close_blocked_by_self_update(model: &WizardModel) {
+    with_ui_frame(|frame| {
+        let dialog = MessageDialog::builder(
+            frame,
+            &model.text.close_during_self_update_body,
+            &model.text.close_during_self_update_title,
+        )
+        .with_style(
+            MessageDialogStyle::OK
+                | MessageDialogStyle::IconInformation
+                | MessageDialogStyle::Centre,
+        )
+        .build();
+        dialog.show_modal();
+    });
 }
 
 fn render_self_update_status(
@@ -1250,12 +1423,19 @@ fn format_bytes_human(bytes: u64) -> String {
 /// touch the package spec list — the install handler builds the maps
 /// once, before spawning the worker thread, and they're shared via
 /// `Arc<HashMap<…>>`.
+///
+/// `status_frozen` holds the status label at whatever the close handler
+/// wrote there. Without it the next download or install event would paint
+/// "Downloading OSARA…" over "Stopping…" and the wizard would look like it
+/// had ignored the user. The log lines below keep flowing either way, so the
+/// step that is still finishing stays visible.
 fn apply_progress_event_to_ui(
     state: &Arc<Mutex<ProgressUiState>>,
     widgets: &WizardWidgets,
     package_display_names: &Arc<HashMap<String, String>>,
     configuration_display_names: &Arc<HashMap<String, String>>,
     event: ProgressEvent,
+    status_frozen: bool,
 ) {
     let mut state = state.lock().unwrap();
     let mut status_line: Option<String> = None;
@@ -1416,7 +1596,9 @@ fn apply_progress_event_to_ui(
     });
 
     widgets.progress_gauge.set_value(state.percentage());
-    if let Some(line) = status_line {
+    if let Some(line) = status_line
+        && !status_frozen
+    {
         widgets.progress_status.set_label(&line);
     }
     // Hold the lock no longer than necessary — the TextCtrl call below
@@ -1558,6 +1740,7 @@ pub fn run() {
         let last_report = Arc::new(Mutex::new(None::<WizardOutcomeReport>));
         let last_reaper_app_path = Arc::new(Mutex::new(None::<PathBuf>));
         let last_resource_path = Arc::new(Mutex::new(None::<PathBuf>));
+        let install_run = Arc::new(InstallRunState::default());
         // Build the wizard pages first, the buttons row, then the language
         // footer. Footer is constructed after the buttons so its widgets
         // come *after* the buttons in tab order, but it needs to exist
@@ -1828,6 +2011,7 @@ pub fn run() {
             let last_report = Arc::clone(&last_report);
             let last_reaper_app_path = Arc::clone(&last_reaper_app_path);
             let last_resource_path = Arc::clone(&last_resource_path);
+            let install_run = Arc::clone(&install_run);
             install.on_click(move |_| {
                 current_step.store(PROGRESS_STEP, Ordering::SeqCst);
                 update_navigation(
@@ -2110,6 +2294,7 @@ pub fn run() {
                 // or status after the completion closure wrote the outcome.
                 let operation_finished = Arc::new(std::sync::atomic::AtomicBool::new(false));
                 let operation_finished_for_reporter = Arc::clone(&operation_finished);
+                let install_run_for_reporter = Arc::clone(&install_run);
                 let progress = ProgressReporter::new(move |event| {
                     // The reporter fires on the worker thread; forward each
                     // event to the UI thread so the gauge / status / log can
@@ -2124,6 +2309,7 @@ pub fn run() {
                     let configuration_display_names =
                         Arc::clone(&configuration_display_names_for_reporter);
                     let widgets = progress_widgets;
+                    let status_frozen = install_run_for_reporter.stop_requested();
                     wxdragon::call_after(Box::new(move || {
                         apply_progress_event_to_ui(
                             &state,
@@ -2131,12 +2317,15 @@ pub fn run() {
                             &package_display_names,
                             &configuration_display_names,
                             event,
+                            status_frozen,
                         );
                     }));
                 });
 
+                let cancel = install_run.begin();
+                let install_run_for_worker = Arc::clone(&install_run);
                 std::thread::spawn(move || {
-                    let result = execute_wizard_install_with_progress(request, &progress);
+                    let result = execute_wizard_install_with_progress(request, &progress, &cancel);
                     operation_finished.store(true, std::sync::atomic::Ordering::Relaxed);
                     wxdragon::call_after(Box::new(move || {
                         widgets.progress_gauge.set_value(100);
@@ -2168,10 +2357,14 @@ pub fn run() {
                                 }
                                 // The operation returns Ok even when some
                                 // packages failed (it installs everything it
-                                // can). Pick an honest heading: a plain
-                                // "success" line would contradict the
-                                // "finished with errors" summary otherwise.
-                                let heading = if report.package_operation.has_failures() {
+                                // can), and when the user stopped it partway.
+                                // Pick an honest heading: a plain "success"
+                                // line would contradict the "finished with
+                                // errors" summary otherwise, and a stopped run
+                                // is neither of those.
+                                let heading = if report.was_cancelled() {
+                                    &ui_model.text.done_status_cancelled
+                                } else if report.package_operation.has_failures() {
                                     &ui_model.text.done_status_completed_with_errors
                                 } else {
                                     &ui_model.text.done_status_success
@@ -2267,6 +2460,16 @@ pub fn run() {
                         // and action buttons instead of cycling back to
                         // an earlier widget.
                         widgets.done_status.set_focus();
+                        // The worker is done and everything it held has been
+                        // dropped, so the window can go now. Force the close:
+                        // there is nothing left to ask the user about, and the
+                        // close handler would otherwise re-open the same
+                        // question it already answered.
+                        let close_now = install_run_for_worker.stop_requested();
+                        install_run_for_worker.finish();
+                        if close_now {
+                            with_ui_frame(|frame| frame.close(true));
+                        }
                     }));
                 });
             });
@@ -2274,8 +2477,65 @@ pub fn run() {
 
         let frame_for_close = frame;
         close.on_click(move |_| {
-            frame_for_close.close(true);
+            // Not forced: the frame's close handler has to be able to stop
+            // this while an install is running.
+            frame_for_close.close(false);
         });
+
+        // Every route out of the wizard — the Close button, the window's
+        // close box, Alt+F4, Cmd+Q — arrives here, which is the one place
+        // that knows whether it is safe to go.
+        {
+            let model_for_close = Arc::clone(&model);
+            let install_run = Arc::clone(&install_run);
+            let widgets = wizard_widgets;
+            let close_button = close;
+            frame.on_close(move |event| {
+                match close_verdict(&install_run) {
+                    CloseVerdict::Allow => {
+                        // Let wxWidgets' own frame handler run and destroy
+                        // the window. Nothing is in flight, so there is
+                        // nothing to unwind.
+                        event.skip(true);
+                    }
+                    CloseVerdict::SelfUpdateInProgress => {
+                        // Not a question: there is no answer that makes
+                        // quitting safe here, so say what is happening
+                        // instead of offering a choice RABBIT can't honour.
+                        show_close_blocked_by_self_update(&model_for_close);
+                    }
+                    CloseVerdict::AlreadyStopping => {
+                        // A second press while the first stop is still
+                        // unwinding. Re-announce rather than re-ask.
+                        announce_stopping(&widgets, &model_for_close);
+                    }
+                    CloseVerdict::Ask => {
+                        if !confirm_stop_install(&model_for_close) {
+                            return;
+                        }
+                        if !install_run.request_stop_and_close() {
+                            // The install finished while the question was on
+                            // screen, so there is nothing left to stop and
+                            // nobody left to close the window for us. Queue
+                            // the close for the next turn of the event loop
+                            // rather than re-entering this handler from
+                            // inside itself.
+                            wxdragon::call_after(Box::new(|| {
+                                with_ui_frame(|frame| frame.close(true));
+                            }));
+                            return;
+                        }
+                        // The button that raised the question is now the
+                        // wrong thing to press again.
+                        close_button.enable(false);
+                        announce_stopping(&widgets, &model_for_close);
+                    }
+                }
+                // Every branch except `Allow` falls through without
+                // skipping, which is what keeps the window alive: the
+                // default handler that would destroy it never runs.
+            });
+        }
 
         // Handle the application-menu Quit item: the macOS menu bar
         // installed below carries a stock wxID_EXIT item, which wxOSX
@@ -2288,7 +2548,7 @@ pub fn run() {
             let frame_for_quit = frame;
             frame.on_menu_selected(move |event| {
                 if event.get_id() == wxdragon::id::ID_EXIT {
-                    frame_for_quit.close(true);
+                    frame_for_quit.close(false);
                 }
             });
         }
@@ -3423,6 +3683,10 @@ fn start_self_update_apply(
     // a modal dialog's nested event loop would let run but would also trap
     // the exit-after-relaunch behind its own dismissal.
     open_self_update_progress_window(&model);
+    // Held for the whole swap so the close handler refuses to quit under a
+    // half-replaced RABBIT. Cleared on every exit from the worker, including
+    // the failure paths — the relaunch path exits the process instead.
+    SELF_UPDATE_APPLYING.store(true, Ordering::SeqCst);
     let model_for_thread = Arc::clone(&model);
     std::thread::spawn(move || {
         // Every event crosses back to the UI thread — widgets must not be
@@ -3434,6 +3698,7 @@ fn start_self_update_apply(
             }));
         });
         let result = run_wizard_self_update_apply(&progress);
+        SELF_UPDATE_APPLYING.store(false, Ordering::SeqCst);
         wxdragon::call_after(Box::new(close_self_update_progress_window));
         wxdragon::call_after(Box::new(move || match result {
             Ok(report) => {

--- a/locales/de-DE/rabbit.ftl
+++ b/locales/de-DE/rabbit.ftl
@@ -199,6 +199,9 @@ wizard-review-package = { $package }: { $action }
 wizard-progress-heading = Installationsfortschritt
 wizard-progress-status-idle = Bereit zur Installation.
 wizard-progress-status-running = Ausgewählte Pakete werden installiert. Dies kann mehrere Minuten dauern.
+# Shown from the moment the user confirms the stop until the pipeline finishes
+# the step it is on. Not "stopped": nothing has stopped yet when it appears.
+wizard-progress-status-cancelling = Wird angehalten. RABBIT beendet den begonnenen Schritt und schließt sich dann.
 wizard-progress-details-label = Fortschrittsdetails
 wizard-progress-details-idle = Es läuft keine Installation.
 wizard-progress-details-starting = Einrichtungsvorgang wird gestartet.
@@ -227,6 +230,7 @@ wizard-done-status-idle = Aus diesem Fenster wurde noch keine Installation ausge
 wizard-done-status-success = Installation abgeschlossen. Bitte prüfen Sie die Details unten.
 wizard-done-status-error = Installation fehlgeschlagen. Bitte prüfen Sie den Fehler unten.
 wizard-done-status-completed-with-errors = Installation mit Fehlern abgeschlossen. Bitte prüfen Sie die Details unten.
+wizard-done-status-cancelled = Sie haben die Installation angehalten. Die Liste unten zeigt, was RABBIT vorher fertiggestellt hat.
 wizard-done-status-no-packages = Es wurde kein Paket zur Installation oder Aktualisierung ausgewählt.
 wizard-done-show-details = Details anzeigen
 # Mnemonic messages are single-character native access keys. Choose a character
@@ -242,6 +246,16 @@ wizard-done-self-update-apply-running = RABBIT-Aktualisierung wird angewendet…
 wizard-done-self-update-error-prefix = RABBIT-Selbstaktualisierung fehlgeschlagen
 wizard-done-self-update-relaunch-prefix = RABBIT neu gestartet
 wizard-self-update-status-checking = Suche nach RABBIT-Aktualisierungen…
+
+# Asked when the user closes the window while an install is running. The No
+# button is the focused one, so a stray Enter never ends a running install.
+wizard-close-during-install-title = Installation anhalten?
+wizard-close-during-install-body = RABBIT installiert gerade. Wenn Sie jetzt anhalten, beendet RABBIT den begonnenen Schritt, behält das bereits Installierte, räumt Angefangenes auf und schließt sich dann. Pakete, die noch nicht an der Reihe waren, bleiben nicht installiert. Installation anhalten?
+
+# Shown instead when the user closes the window while RABBIT is replacing its
+# own files. Not a question: that swap has no safe interruption point.
+wizard-close-during-self-update-title = RABBIT aktualisiert sich selbst
+wizard-close-during-self-update-body = RABBIT ersetzt gerade seine eigenen Programmdateien. Dieser Schritt lässt sich nicht anhalten, ohne die Installation zu beschädigen. Warten Sie, bis er fertig ist, und schließen Sie RABBIT danach.
 
 # Modaler Dialog, der einmal pro Sitzung erscheint, wenn die Startprüfung
 # eine neuere Version findet. Titel ist kurz, der Text verwendet dieselben
@@ -313,6 +327,7 @@ status-deferred-unattended = Unbeaufsichtigt verschoben
 status-skipped-current = Übersprungen (bereits aktuell)
 status-failed = Fehlgeschlagen
 status-skipped-dependency-failed = Übersprungen (Abhängigkeit fehlgeschlagen)
+status-cancelled = Nicht installiert (von Ihnen angehalten)
 
 # Paketstatus-Meldungen, die auf der Fertig-Seite des Assistenten neben dem
 # Paketnamen erscheinen (z. B. „OSARA: <Meldung>"). Die Wrapper-Vorlage
@@ -324,6 +339,7 @@ package-status-skipped-current = Installierte Version { $installed } ist aktuell
 package-status-skipped-content-unchanged = Die installierte Fassung ist identisch mit der beim Herausgeber veröffentlichten.
 package-status-install-failed = Installation fehlgeschlagen: { $error }
 package-status-skipped-dependency-failed = Übersprungen, weil { $dependency }, was dafür benötigt wird, nicht erfolgreich installiert wurde.
+package-status-cancelled = Nicht installiert: Sie haben die Einrichtung angehalten, bevor RABBIT dieses Paket erreicht hat.
 # $automation ist einer der „package-automation-*"-Texte (Vendor-Installationsprogramm / Archiv-Entpacken / …).
 package-status-dry-run-would-run-unattended = Probelauf: RABBIT würde dieses { $automation } unbeaufsichtigt herunterladen und ausführen.
 # $automation ist einer der „package-automation-*"-Texte.
@@ -358,6 +374,7 @@ config-message-skipped = Konfigurationsschritt { $step } wurde nicht ausgewählt
 # $step ist die Schritt-Kennung; $dependency ist die Kennung des abhängigen Pakets.
 config-message-skipped-dependency-missing = Konfigurationsschritt { $step } übersprungen, weil das abhängige Paket { $dependency } weder installiert ist noch zu diesem Lauf gehört.
 config-message-applied-no-op = Konfigurationsschritt ohne Änderungen angewendet.
+config-message-cancelled = Dieser Konfigurationsschritt wurde nicht ausgeführt: Sie haben die Einrichtung vorher angehalten.
 
 # Statuszeile pro Konfigurationsschritt auf der Fertig-Seite, analog zu
 # `wizard-summary-package-status` für die Pakete.
@@ -369,6 +386,7 @@ config-status-applied = Angewendet
 config-status-skipped = Übersprungen
 config-status-skipped-dependency-missing = Übersprungen (Abhängigkeit fehlt)
 config-status-dry-run = Probelauf
+config-status-cancelled = Nicht ausgeführt (von Ihnen angehalten)
 wizard-summary-planned-execution-title = Geplante unbeaufsichtigte Ausführung:
 wizard-summary-planned-execution-runner =   Ausführer: { $runner }
 wizard-summary-planned-execution-artifact =   Artefakt: { $artifact }

--- a/locales/en-US/rabbit.ftl
+++ b/locales/en-US/rabbit.ftl
@@ -199,6 +199,9 @@ wizard-review-package = { $package }: { $action }
 wizard-progress-heading = Installation progress
 wizard-progress-status-idle = Ready to install.
 wizard-progress-status-running = Installing selected packages. This might take a few minutes.
+# Shown from the moment the user confirms the stop until the pipeline finishes
+# the step it is on. Not "stopped": nothing has stopped yet when it appears.
+wizard-progress-status-cancelling = Stopping. RABBIT is finishing the step it started, then it closes.
 wizard-progress-details-label = Progress details
 wizard-progress-details-idle = No installation is running.
 wizard-progress-details-starting = Starting setup operation.
@@ -227,6 +230,7 @@ wizard-done-status-idle = No installation has been run from this window yet.
 wizard-done-status-success = RABBIT finished working its magic! Review the details below.
 wizard-done-status-error = Installation failed. Review the error below.
 wizard-done-status-completed-with-errors = Installation completed with errors. Review the details below.
+wizard-done-status-cancelled = You stopped the installation. The list below shows what RABBIT finished before it stopped.
 wizard-done-status-no-packages = No package was selected for installation or update.
 wizard-done-show-details = Show details
 # Mnemonic messages are single-character native access keys. Choose a character
@@ -242,6 +246,16 @@ wizard-done-self-update-apply-running = Applying RABBIT update…
 wizard-done-self-update-error-prefix = RABBIT self-update failed
 wizard-done-self-update-relaunch-prefix = Relaunched RABBIT
 wizard-self-update-status-checking = Checking for RABBIT updates…
+
+# Asked when the user closes the window while an install is running. The No
+# button is the focused one, so a stray Enter never ends a running install.
+wizard-close-during-install-title = Stop the installation?
+wizard-close-during-install-body = RABBIT is installing. If you stop now, RABBIT finishes the step it started, keeps what is already installed, cleans up what it started, and then closes. Packages it has not reached yet stay uninstalled. Stop the installation?
+
+# Shown instead when the user closes the window while RABBIT is replacing its
+# own files. Not a question: that swap has no safe interruption point.
+wizard-close-during-self-update-title = RABBIT is updating itself
+wizard-close-during-self-update-body = RABBIT is replacing its own program files. This step cannot be stopped without damaging the installation. Wait for it to finish, then close RABBIT.
 
 # Modal dialog shown once per session when a startup self-update check finds a
 # newer release. Title is short; body uses the same { $current } / { $latest }
@@ -313,6 +327,7 @@ status-deferred-unattended = Deferred unattended
 status-skipped-current = Skipped (already current)
 status-failed = Failed
 status-skipped-dependency-failed = Skipped (dependency failed)
+status-cancelled = Not installed (you stopped)
 
 # Per-package status messages surfaced on the wizard's Done page next to the
 # package name (e.g. "OSARA: <message>"). The wrapper template
@@ -325,6 +340,7 @@ package-status-skipped-content-unchanged = The installed copy is identical to th
 # $error is the failure text. $dependency is the package (e.g. REAPER) that failed first.
 package-status-install-failed = Installation failed: { $error }
 package-status-skipped-dependency-failed = Skipped because { $dependency }, which it needs, did not install successfully.
+package-status-cancelled = Not installed: you stopped the setup before RABBIT reached this package.
 # $automation is one of the "package-automation-*" labels (vendor installer / archive extraction / ...).
 package-status-dry-run-would-run-unattended = Dry run: RABBIT would download and run this { $automation } unattended.
 # $automation is one of the "package-automation-*" labels.
@@ -358,6 +374,7 @@ config-message-skipped = Configuration step { $step } was not selected.
 # $step is the configuration step id; $dependency is the dependency package id.
 config-message-skipped-dependency-missing = Configuration step { $step } skipped because its dependency package { $dependency } was not installed and is not part of this plan.
 config-message-applied-no-op = Configuration step applied without changes.
+config-message-cancelled = This configuration step did not run: you stopped the setup first.
 
 # Per-configuration-step status sub-line on the Done page. Sibling to
 # `wizard-summary-package-status` which handles per-package items.
@@ -369,6 +386,7 @@ config-status-applied = Applied
 config-status-skipped = Skipped
 config-status-skipped-dependency-missing = Skipped (dependency missing)
 config-status-dry-run = Dry run
+config-status-cancelled = Did not run (you stopped)
 wizard-summary-planned-execution-title = Planned unattended execution:
 wizard-summary-planned-execution-runner =   Runner: { $runner }
 wizard-summary-planned-execution-artifact =   Artifact: { $artifact }

--- a/locales/es-ES/rabbit.ftl
+++ b/locales/es-ES/rabbit.ftl
@@ -199,6 +199,9 @@ wizard-review-package = { $package }: { $action }
 wizard-progress-heading = Progreso de la instalación
 wizard-progress-status-idle = Listo para instalar.
 wizard-progress-status-running = Instalando paquetes seleccionados. Esto puede tardar unos minutos.
+# Shown from the moment the user confirms the stop until the pipeline finishes
+# the step it is on. Not "stopped": nothing has stopped yet when it appears.
+wizard-progress-status-cancelling = Deteniendo. RABBIT termina el paso que empezó y luego se cierra.
 wizard-progress-details-label = Detalles del progreso
 wizard-progress-details-idle = Sin instalación en curso.
 wizard-progress-details-starting = Iniciando operaciones de instalación.
@@ -227,6 +230,7 @@ wizard-done-status-idle = Todavía no se ejecutó una instalación desde esta ve
 wizard-done-status-success = ¡RABBIT terminó de hacer su magia! Revisar los detalles acontinuación.
 wizard-done-status-error = La instalación ha fallado. Revisa el error acontinuación.
 wizard-done-status-completed-with-errors = La instalación se completó con errores. Revisa los detalles a continuación.
+wizard-done-status-cancelled = Has detenido la instalación. La lista de abajo muestra lo que RABBIT terminó antes de pararse.
 wizard-done-status-no-packages = No se ha seleccionado ningún paquete para instalar o actualizar.
 wizard-done-show-details = Mostrar detalles
 # Mnemonic messages are single-character native access keys. Choose a character
@@ -242,6 +246,16 @@ wizard-done-self-update-apply-running = Actualizando RABBIT…
 wizard-done-self-update-error-prefix = La actualización de RABBIT falló.
 wizard-done-self-update-relaunch-prefix = RABBIT reiniciado
 wizard-self-update-status-checking = Comprobando actualizaciones de RABBIT…
+
+# Asked when the user closes the window while an install is running. The No
+# button is the focused one, so a stray Enter never ends a running install.
+wizard-close-during-install-title = ¿Detener la instalación?
+wizard-close-during-install-body = RABBIT está instalando. Si lo detienes ahora, RABBIT termina el paso que empezó, conserva lo que ya está instalado, limpia lo que empezó y luego se cierra. Los paquetes a los que todavía no ha llegado se quedan sin instalar. ¿Quieres detener la instalación?
+
+# Shown instead when the user closes the window while RABBIT is replacing its
+# own files. Not a question: that swap has no safe interruption point.
+wizard-close-during-self-update-title = RABBIT se está actualizando
+wizard-close-during-self-update-body = RABBIT está reemplazando sus propios archivos de programa. Este paso no se puede detener sin dañar la instalación. Espera a que termine y cierra RABBIT después.
 
 # Modal dialog shown once per session when a startup self-update check finds a
 # newer release. Title is short; body uses the same { $current } / { $latest }
@@ -313,6 +327,7 @@ status-deferred-unattended = Plan diferido
 status-skipped-current = Omitido (ya existe)
 status-failed = Fallido
 status-skipped-dependency-failed = Omitido (falló una dependencia)
+status-cancelled = No instalado (lo detuviste)
 
 # Per-package status messages surfaced on the wizard's Done page next to the
 # package name (e.g. "OSARA: <message>"). The wrapper template
@@ -325,6 +340,7 @@ package-status-skipped-content-unchanged = La copia instalada es idéntica a la 
 # $error es el texto del error. $dependency es el paquete (p. ej. REAPER) que falló primero.
 package-status-install-failed = La instalación falló: { $error }
 package-status-skipped-dependency-failed = Omitido porque { $dependency }, que necesita, no se instaló correctamente.
+package-status-cancelled = No instalado: detuviste la configuración antes de que RABBIT llegara a este paquete.
 # $automation is one of the "package-automation-*" labels (vendor installer / archive extraction / ...).
 package-status-dry-run-would-run-unattended = Dry run: RABBIT Va a descargar y ejecutar esta { $automation } desatendida.
 # $automation is one of the "package-automation-*" labels.
@@ -358,6 +374,7 @@ config-message-skipped = El paso de configuración { $step } No se ha selecciona
 # $step is the configuration step id; $dependency is the dependency package id.
 config-message-skipped-dependency-missing = El paso de configuración { $step } se saltó porque los paquetes dependientes  { $dependency } no se han instalado, y tampoco son parte de este plan.
 config-message-applied-no-op = Se aplicaron los pasos de configuración sin cambios
+config-message-cancelled = Este paso de configuración no se ejecutó: detuviste la configuración antes.
 
 # Per-configuration-step status sub-line on the Done page. Sibling to
 # `wizard-summary-package-status` which handles per-package items.
@@ -369,6 +386,7 @@ config-status-applied = Aplicado
 config-status-skipped = Omitido
 config-status-skipped-dependency-missing = Omitido  (falta dependencia)
 config-status-dry-run = Dry ejecutado
+config-status-cancelled = No se ejecutó (lo detuviste)
 wizard-summary-planned-execution-title = Ejecución desatendida planeada:
 wizard-summary-planned-execution-runner =   Se ejecuta: { $runner }
 wizard-summary-planned-execution-artifact =   Artefacto: { $artifact }

--- a/locales/fr-FR/rabbit.ftl
+++ b/locales/fr-FR/rabbit.ftl
@@ -199,6 +199,9 @@ wizard-review-package = { $package } : { $action }
 wizard-progress-heading = Progression de l'installation
 wizard-progress-status-idle = Prêt à installer.
 wizard-progress-status-running = Installation des paquets sélectionnés. Cela peut prendre quelques minutes.
+# Shown from the moment the user confirms the stop until the pipeline finishes
+# the step it is on. Not "stopped": nothing has stopped yet when it appears.
+wizard-progress-status-cancelling = Arrêt en cours. RABBIT termine l'étape commencée, puis se ferme.
 wizard-progress-details-label = Détails de la progression
 wizard-progress-details-idle = Aucune installation en cours.
 wizard-progress-details-starting = Démarrage de l'opération de configuration.
@@ -227,6 +230,7 @@ wizard-done-status-idle = Aucune installation n'a encore été lancée depuis ce
 wizard-done-status-success = RABBIT a fini d'opérer sa magie ! Consultez les détails ci-dessous.
 wizard-done-status-error = L'installation a échoué. Consultez l'erreur ci-dessous.
 wizard-done-status-completed-with-errors = Installation terminée avec des erreurs. Consultez les détails ci-dessous.
+wizard-done-status-cancelled = Vous avez arrêté l'installation. La liste ci-dessous montre ce que RABBIT a terminé avant de s'arrêter.
 wizard-done-status-no-packages = Aucun paquet n'a été sélectionné pour l'installation ou la mise à jour.
 wizard-done-show-details = Afficher les détails
 # Mnemonic messages are single-character native access keys. Choose a character
@@ -242,6 +246,16 @@ wizard-done-self-update-apply-running = Application de la mise à jour de RABBIT
 wizard-done-self-update-error-prefix = La mise à jour automatique de RABBIT a échoué
 wizard-done-self-update-relaunch-prefix = RABBIT relancé
 wizard-self-update-status-checking = Recherche de mises à jour de RABBIT…
+
+# Asked when the user closes the window while an install is running. The No
+# button is the focused one, so a stray Enter never ends a running install.
+wizard-close-during-install-title = Arrêter l'installation ?
+wizard-close-during-install-body = RABBIT est en train d'installer. Si vous arrêtez maintenant, RABBIT termine l'étape commencée, conserve ce qui est déjà installé, nettoie ce qu'il a commencé, puis se ferme. Les paquets qu'il n'a pas encore atteints restent non installés. Arrêter l'installation ?
+
+# Shown instead when the user closes the window while RABBIT is replacing its
+# own files. Not a question: that swap has no safe interruption point.
+wizard-close-during-self-update-title = RABBIT se met à jour
+wizard-close-during-self-update-body = RABBIT remplace ses propres fichiers de programme. Cette étape ne peut pas être arrêtée sans endommager l'installation. Attendez la fin, puis fermez RABBIT.
 
 # Modal dialog shown once per session when a startup self-update check finds a
 # newer release. Title is short; body uses the same { $current } / { $latest }
@@ -313,6 +327,7 @@ status-deferred-unattended = Différé sans intervention
 status-skipped-current = Ignoré (déjà à jour)
 status-failed = Échec
 status-skipped-dependency-failed = Ignoré (dépendance en échec)
+status-cancelled = Non installé (vous avez arrêté)
 
 # Per-package status messages surfaced on the wizard's Done page next to the
 # package name (e.g. "OSARA: <message>"). The wrapper template
@@ -324,6 +339,7 @@ package-status-skipped-current = La version installée { $installed } est égale
 package-status-skipped-content-unchanged = La copie installée est identique à celle publiée par l'éditeur.
 package-status-install-failed = Échec de l'installation : { $error }
 package-status-skipped-dependency-failed = Ignoré car { $dependency }, dont il dépend, ne s'est pas installé correctement.
+package-status-cancelled = Non installé : vous avez arrêté la configuration avant que RABBIT n'atteigne ce paquet.
 # $automation is one of the "package-automation-*" labels (vendor installer / archive extraction / ...).
 package-status-dry-run-would-run-unattended = Simulation : RABBIT téléchargerait et exécuterait l'opération « { $automation } » sans intervention.
 # $automation is one of the "package-automation-*" labels.
@@ -357,6 +373,7 @@ config-message-skipped = L'étape de configuration { $step } n'a pas été séle
 # $step is the configuration step id; $dependency is the dependency package id.
 config-message-skipped-dependency-missing = L'étape de configuration { $step } a été ignorée car son paquet prérequis { $dependency } n'était pas installé et ne fait pas partie de ce plan.
 config-message-applied-no-op = Étape de configuration appliquée sans modification.
+config-message-cancelled = Cette étape de configuration n'a pas été exécutée : vous avez arrêté la configuration avant.
 
 # Per-configuration-step status sub-line on the Done page. Sibling to
 # `wizard-summary-package-status` which handles per-package items.
@@ -368,6 +385,7 @@ config-status-applied = Appliqué
 config-status-skipped = Ignoré
 config-status-skipped-dependency-missing = Ignoré (prérequis manquant)
 config-status-dry-run = Simulation
+config-status-cancelled = Non exécutée (vous avez arrêté)
 wizard-summary-planned-execution-title = Exécution sans intervention prévue :
 wizard-summary-planned-execution-runner =   Exécuteur : { $runner }
 wizard-summary-planned-execution-artifact =   Artefact : { $artifact }

--- a/locales/it-IT/rabbit.ftl
+++ b/locales/it-IT/rabbit.ftl
@@ -199,6 +199,9 @@ wizard-review-package = { $package }: { $action }
 wizard-progress-heading = Avanzamento dell'installazione
 wizard-progress-status-idle = Pronto per l'installazione.
 wizard-progress-status-running = Installazione dei pacchetti selezionati. Potrebbe richiedere alcuni minuti.
+# Shown from the moment the user confirms the stop until the pipeline finishes
+# the step it is on. Not "stopped": nothing has stopped yet when it appears.
+wizard-progress-status-cancelling = Arresto in corso. RABBIT termina il passaggio iniziato, poi si chiude.
 wizard-progress-details-label = Dettagli dell'avanzamento
 wizard-progress-details-idle = Nessuna installazione in corso.
 wizard-progress-details-starting = Avvio dell'operazione di configurazione.
@@ -227,6 +230,7 @@ wizard-done-status-idle = Nessuna installazione è ancora stata avviata da quest
 wizard-done-status-success = RABBIT ha finito di fare la sua magia! Consulta i dettagli qui sotto.
 wizard-done-status-error = Installazione non riuscita. Consulta l'errore qui sotto.
 wizard-done-status-completed-with-errors = Installazione completata con errori. Consulta i dettagli qui sotto.
+wizard-done-status-cancelled = Hai interrotto l'installazione. L'elenco qui sotto mostra ciò che RABBIT ha completato prima di fermarsi.
 wizard-done-status-no-packages = Nessun pacchetto è stato selezionato per l'installazione o l'aggiornamento.
 wizard-done-show-details = Mostra dettagli
 # Mnemonic messages are single-character native access keys. Choose a character
@@ -242,6 +246,16 @@ wizard-done-self-update-apply-running = Applicazione dell'aggiornamento di RABBI
 wizard-done-self-update-error-prefix = Aggiornamento automatico di RABBIT non riuscito
 wizard-done-self-update-relaunch-prefix = RABBIT riavviato
 wizard-self-update-status-checking = Ricerca di aggiornamenti di RABBIT…
+
+# Asked when the user closes the window while an install is running. The No
+# button is the focused one, so a stray Enter never ends a running install.
+wizard-close-during-install-title = Interrompere l'installazione?
+wizard-close-during-install-body = RABBIT sta installando. Se interrompi adesso, RABBIT completa il passaggio iniziato, mantiene ciò che è già installato, ripulisce quello che ha iniziato e poi si chiude. I pacchetti che non ha ancora raggiunto restano non installati. Vuoi interrompere l'installazione?
+
+# Shown instead when the user closes the window while RABBIT is replacing its
+# own files. Not a question: that swap has no safe interruption point.
+wizard-close-during-self-update-title = RABBIT si sta aggiornando
+wizard-close-during-self-update-body = RABBIT sta sostituendo i propri file di programma. Questo passaggio non può essere interrotto senza danneggiare l'installazione. Attendi che finisca, poi chiudi RABBIT.
 
 # Modal dialog shown once per session when a startup self-update check finds a
 # newer release. Title is short; body uses the same { $current } / { $latest }
@@ -313,6 +327,7 @@ status-deferred-unattended = Rinviato in modo automatico
 status-skipped-current = Ignorato (già aggiornato)
 status-failed = Non riuscito
 status-skipped-dependency-failed = Saltato (dipendenza non riuscita)
+status-cancelled = Non installato (hai interrotto)
 
 # Per-package status messages surfaced on the wizard's Done page next to the
 # package name (e.g. "OSARA: <message>"). The wrapper template
@@ -324,6 +339,7 @@ package-status-skipped-current = La versione installata { $installed } è uguale
 package-status-skipped-content-unchanged = La copia installata è identica a quella pubblicata dall'editore.
 package-status-install-failed = Installazione non riuscita: { $error }
 package-status-skipped-dependency-failed = Saltato perché { $dependency }, da cui dipende, non è stato installato correttamente.
+package-status-cancelled = Non installato: hai interrotto la configurazione prima che RABBIT arrivasse a questo pacchetto.
 # $automation is one of the "package-automation-*" labels (vendor installer / archive extraction / ...).
 package-status-dry-run-would-run-unattended = Simulazione: RABBIT scaricherebbe ed eseguirebbe l'operazione «{ $automation }» in modo automatico.
 # $automation is one of the "package-automation-*" labels.
@@ -357,6 +373,7 @@ config-message-skipped = Il passaggio di configurazione { $step } non è stato s
 # $step is the configuration step id; $dependency is the dependency package id.
 config-message-skipped-dependency-missing = Il passaggio di configurazione { $step } è stato ignorato perché il suo pacchetto prerequisito { $dependency } non era installato e non fa parte di questo piano.
 config-message-applied-no-op = Passaggio di configurazione applicato senza modifiche.
+config-message-cancelled = Questo passaggio di configurazione non è stato eseguito: hai interrotto prima la configurazione.
 
 # Per-configuration-step status sub-line on the Done page. Sibling to
 # `wizard-summary-package-status` which handles per-package items.
@@ -368,6 +385,7 @@ config-status-applied = Applicato
 config-status-skipped = Ignorato
 config-status-skipped-dependency-missing = Ignorato (prerequisito mancante)
 config-status-dry-run = Simulazione
+config-status-cancelled = Non eseguito (hai interrotto)
 wizard-summary-planned-execution-title = Esecuzione automatica prevista:
 wizard-summary-planned-execution-runner =   Esecutore: { $runner }
 wizard-summary-planned-execution-artifact =   Artefatto: { $artifact }


### PR DESCRIPTION
Closing the window during an install ended the process wherever the worker happened to be: mid-download, mid-extract, or between a vendor installer finishing and RABBIT writing the receipt that records it. Nothing unwound, because nothing got the chance to — no `Drop` ran, so the install lock file, the extraction temp dirs and any `.part` downloads stayed behind, and the user was left with no record of what had actually landed on their machine.

The close button now talks to the worker instead of killing it.

### What changes

- Closing during an install asks first: **Stop the installation?** with **No** as the focused button. That dialog appears over work the user asked for, so `wxNO_DEFAULT` is doing real work here — a stray Enter from someone tabbing around the progress page must not be what ends their REAPER install.
- On Yes, the close is vetoed, the status line reads *"Stopping. RABBIT is finishing the step it started, then it closes."*, and the pipeline stops at its next package boundary. It unwinds the ordinary way, writes its report, and the completion closure closes the window for real.
- The result page has a third outcome next to "finished" and "finished with errors": a stopped run lists which packages installed and which RABBIT never reached, and reports neither as a failure.
- Closing during a **self-update** is refused rather than obeyed, with an explanation instead of a question. This is the other half of the decision recorded in #21: the download is cancellable, the apply is not, and a window that closes over a half-replaced executable is the same lie as a Cancel button that can't cancel.

### How it's wired

A `CancelToken` in `rabbit-core::cancel`, threaded next to `ProgressReporter` — events go out, cancellation comes back. The `_with_progress` entry points gained the parameter; the plain ones pass a fresh token, the same way they already pass `ProgressReporter::noop()`, so the CLI and every existing caller are untouched.

Cancellation is deliberately coarse. The token is read at package boundaries, between configuration steps, and inside the download loop's existing chunk/retry checkpoints — not inside a step. Whatever is running when the flag goes up runs to completion: an elevated vendor installer has no halfway point to return to, and a file copy already under way is safer finished than abandoned. So the wizard says it is finishing that step rather than pretending the stop is instant.

The pipeline returns `Ok` on a cancel rather than an error. That is what makes the cleanup work — the lock guard and the extraction `TempDir`s release on the normal path — and it is also what lets the report say how far the run got. `PackageOperationStatus::Cancelled` and `ConfigurationStatus::Cancelled` carry that; `was_cancelled()` sits beside `has_failures()` and is deliberately not folded into it, because a cancelled package installed nothing and broke nothing, and calling it a failure sends the user hunting for a problem that isn't there.

The download pool takes a `child()` of the caller's token: the batch can still stop its own workers when one artifact fails, without telling the caller that the whole operation was cancelled.

### Notable decisions

- **All four exits go through one handler.** The Close button, the window's close box, Alt+F4 and Cmd+Q now call `close(false)` so `EVT_CLOSE` can veto. Everything that already knew it was safe to close — the Done page's Enter key, "Open REAPER and close RABBIT", the post-cancel close — keeps forcing.
- **The status label freezes once the user has confirmed.** Otherwise the next download event would paint "Downloading OSARA…" over "Stopping…" and the wizard would look like it had ignored them. The log lines keep flowing, so the step that is still finishing stays visible.
- **The stop is announced through the log, not the status heading.** The heading is a `StaticText`: it can't take focus, and a label change on its own isn't something a screen reader announces. The log is a `TextCtrl`, so focus lands there and the answer to "did it hear me?" is audible.
- **A second press re-announces rather than re-asks.** The X and Alt+F4 still reach the handler after the Close button is disabled.
- **One lock covers "ask the pipeline to stop" and "remember to close".** The confirmation dialog runs a nested event loop, which is exactly what lets the worker's completion closure run mid-question. If the install finishes while the dialog is on screen there is nobody left to close the window, so that case queues the close for the next turn of the event loop instead of re-entering the close handler from inside itself.

### Not covered

Closing during the version-check step still exits immediately. That worker only reads the network and writes nothing, so there is nothing to clean up.

### Testing

`cargo fmt --check` clean, `cargo clippy --workspace --all-targets` and `cargo clippy -p rabbit-ui-wxdragon --features gui --all-targets` clean (no new warnings; the two entry points that crossed clippy's argument limit carry the same `#[allow]` the crate already uses elsewhere), 441 tests pass, and `cargo build -p rabbit --features gui` links.

Six new tests. Four cover the token itself, including that a child follows its parent but cancelling a child leaves the parent alone. Two cover the pipeline:

- a pre-cancelled run reports every package as `Cancelled`, downloads nothing, is not a failure, and **leaves no lock file behind** — the assertion that pins the actual bug;
- cancelling from the progress reporter when the first package's install completes leaves that package installed on disk and the second one `Cancelled`, so a stop keeps the work the user already waited through.

All five interface languages carry the new wording.
