### PR TITLE
fix(windows): stop stray console windows flashing up during installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ from this file and posts it as the GitHub release body.
 
 ### Fixed
 
+- Console windows no longer flash on screen while RABBIT works. RABBIT's
+  release build owns no console of its own, so every console program it
+  launched got a brand new console window from Windows: a PowerShell window
+  when RABBIT added its Defender cache exclusion (the one users noticed,
+  since it only appears on the runs that actually need the exclusion), a
+  `signtool` window during signature checks on machines with the Windows SDK,
+  and a `cmd` window every time the wizard opened a link. All three now run
+  windowless. Vendor installers still show their windows: those are the
+  user's own installers, and hiding them would leave a wizard that looked
+  stalled.
+
 - The **Set REAPER's language** row no longer claims to require one
   particular language pack. It listed every pack it accepts and then named
   whichever sorted first, so a step that any pack satisfies advertised

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,7 @@ name = "rabbit-ui-wxdragon"
 version = "0.4.2"
 dependencies = [
  "rabbit-core",
+ "rabbit-platform",
  "serde",
  "tempfile",
  "wxdragon",

--- a/crates/rabbit-core/src/upstream.rs
+++ b/crates/rabbit-core/src/upstream.rs
@@ -176,10 +176,15 @@ fn execute_program_plan(plan: &PlannedExecutionPlan) -> Result<()> {
 fn execute_program_plan_elevated(plan: &PlannedExecutionPlan, program: &str) -> Result<()> {
     use rabbit_platform::ElevationError;
 
+    // `Show`: these are the vendor's own installers. Even the ones RABBIT
+    // drives silently can fall back to their own progress or error windows,
+    // and hiding those would leave the user in front of a wizard that had
+    // apparently stalled.
     let exit_code = rabbit_platform::run_elevated_and_wait(
         Path::new(program),
         &plan.arguments,
         plan.working_directory.as_deref(),
+        rabbit_platform::ElevatedWindow::Show,
     )
     .map_err(|error| match error {
         ElevationError::UserCancelledElevation { .. } => RabbitError::UserCancelledElevation {

--- a/crates/rabbit-platform/src/defender.rs
+++ b/crates/rabbit-platform/src/defender.rs
@@ -166,18 +166,14 @@ fn powershell_program() -> std::path::PathBuf {
 /// idempotent elevated add.
 #[cfg(windows)]
 fn query_exclusion_paths() -> Option<Vec<String>> {
-    use std::os::windows::process::CommandExt;
-
-    // CREATE_NO_WINDOW: no console flashes for the background read.
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-    let output = std::process::Command::new(powershell_program())
-        .args([
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            "(Get-MpPreference).ExclusionPath -join [Environment]::NewLine",
-        ])
-        .creation_flags(CREATE_NO_WINDOW)
+    let mut command = std::process::Command::new(powershell_program());
+    command.args([
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "(Get-MpPreference).ExclusionPath -join [Environment]::NewLine",
+    ]);
+    let output = crate::process::without_console_window(&mut command)
         .output()
         .ok()?;
     if !output.status.success() {
@@ -195,7 +191,7 @@ fn query_exclusion_paths() -> Option<Vec<String>> {
 /// Add a single Defender path exclusion under UAC elevation.
 #[cfg(windows)]
 fn add_exclusion_elevated(path: &str) -> Result<(), String> {
-    use crate::elevation::{ElevationError, run_elevated_and_wait};
+    use crate::elevation::{ElevatedWindow, ElevationError, run_elevated_and_wait};
 
     // Refuse to interpolate a path that could break out of the PowerShell
     // single-quoted string and inject a command that would then run as
@@ -208,6 +204,10 @@ fn add_exclusion_elevated(path: &str) -> Result<(), String> {
     let escaped = path.replace('\'', "''");
     let command = format!("Add-MpPreference -ExclusionPath '{escaped}'");
     let program = powershell_program();
+    // `-WindowStyle Hidden` only takes effect once the PowerShell host is
+    // already up, so on its own it still let a console window appear and
+    // vanish. `ElevatedWindow::Hidden` is what actually keeps it off screen;
+    // the switch stays as a second line of defence.
     let arguments = vec![
         "-NoProfile".to_string(),
         "-NonInteractive".to_string(),
@@ -216,7 +216,7 @@ fn add_exclusion_elevated(path: &str) -> Result<(), String> {
         "-Command".to_string(),
         command,
     ];
-    match run_elevated_and_wait(&program, &arguments, None) {
+    match run_elevated_and_wait(&program, &arguments, None, ElevatedWindow::Hidden) {
         Ok(Some(0)) => Ok(()),
         Ok(Some(code)) => Err(format!("powershell exited with code {code}")),
         Ok(None) => Err("powershell returned no exit code".to_string()),

--- a/crates/rabbit-platform/src/disk_image.rs
+++ b/crates/rabbit-platform/src/disk_image.rs
@@ -221,7 +221,7 @@ fn platform_run_pkg_installer_from_disk_image(
     image_path: &Path,
     pkg_suffix: &str,
 ) -> Result<PathBuf, DiskImageError> {
-    use crate::elevation::{ElevationError, run_elevated_and_wait};
+    use crate::elevation::{ElevatedWindow, ElevationError, run_elevated_and_wait};
 
     let mount = mount_disk_image(image_path)?;
     let pkg = find_pkg_in_directory(mount.mount_point(), pkg_suffix).ok_or_else(|| {
@@ -238,7 +238,16 @@ fn platform_run_pkg_installer_from_disk_image(
         "/".to_string(),
     ];
 
-    let exit = run_elevated_and_wait(Path::new("/usr/sbin/installer"), &installer_args, None);
+    // `Show`: `installer(8)` is the vendor's own package running under the
+    // user's eyes, same reasoning as the Windows vendor installers. The value
+    // is moot on macOS, where the elevated call runs through `osascript` and
+    // shows no terminal either way.
+    let exit = run_elevated_and_wait(
+        Path::new("/usr/sbin/installer"),
+        &installer_args,
+        None,
+        ElevatedWindow::Show,
+    );
 
     // Detach regardless of installer success so the volume doesn't stay
     // mounted under /Volumes. Best-effort: if the detach itself fails we

--- a/crates/rabbit-platform/src/elevation.rs
+++ b/crates/rabbit-platform/src/elevation.rs
@@ -68,17 +68,55 @@ impl std::fmt::Display for ElevationError {
 
 impl std::error::Error for ElevationError {}
 
+/// Whether the elevated child is allowed to put a window on screen.
+///
+/// This is not cosmetic on Windows. RABBIT's release GUI build owns no
+/// console, so a console-subsystem child launched with a visible show
+/// command gets a console window of its own — which is what made a
+/// PowerShell window flash up mid-install while RABBIT added its Defender
+/// exclusion. The UAC consent dialog is drawn by the system on its own
+/// desktop and is unaffected by either value, so hiding the child never
+/// hides the prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElevatedWindow {
+    /// The child owns UI the user is meant to see. Vendor installers use
+    /// this: even the silent ones may fall back to their own progress or
+    /// error windows, and suppressing those would leave the user staring
+    /// at a wizard that had apparently stopped.
+    Show,
+    /// The child is a console helper doing bookkeeping on RABBIT's behalf,
+    /// with nothing to show and nothing to read.
+    Hidden,
+}
+
+#[cfg(windows)]
+impl ElevatedWindow {
+    /// The `nShow` value `ShellExecuteExW` expects for this choice.
+    fn show_command(self) -> i32 {
+        use windows_sys::Win32::UI::WindowsAndMessaging::{SW_HIDE, SW_SHOWNORMAL};
+
+        match self {
+            Self::Show => SW_SHOWNORMAL,
+            Self::Hidden => SW_HIDE,
+        }
+    }
+}
+
 /// Launch `program` with `arguments` under UAC elevation and block until it
 /// exits. Returns the process exit code (`Some(n)`) on a clean exit, or
 /// `None` if the OS could not return one (rare). Working directory may be
 /// `None` to inherit the current directory.
+///
+/// `window` says whether the child may show a window; see
+/// [`ElevatedWindow`]. It never affects the UAC prompt itself.
 #[cfg_attr(not(windows), allow(unused_variables))]
 pub fn run_elevated_and_wait(
     program: &Path,
     arguments: &[String],
     working_directory: Option<&Path>,
+    window: ElevatedWindow,
 ) -> Result<Option<i32>, ElevationError> {
-    platform_run_elevated_and_wait(program, arguments, working_directory)
+    platform_run_elevated_and_wait(program, arguments, working_directory, window)
 }
 
 #[cfg(windows)]
@@ -86,6 +124,7 @@ fn platform_run_elevated_and_wait(
     program: &Path,
     arguments: &[String],
     working_directory: Option<&Path>,
+    window: ElevatedWindow,
 ) -> Result<Option<i32>, ElevationError> {
     use std::os::windows::ffi::OsStrExt;
 
@@ -96,7 +135,6 @@ fn platform_run_elevated_and_wait(
     use windows_sys::Win32::UI::Shell::{
         SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW,
     };
-    use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
     let verb_w: Vec<u16> = OsStr::new("runas").encode_wide().chain(Some(0)).collect();
     let program_w: Vec<u16> = program.as_os_str().encode_wide().chain(Some(0)).collect();
@@ -123,7 +161,7 @@ fn platform_run_elevated_and_wait(
             .as_ref()
             .map(|w| w.as_ptr())
             .unwrap_or(std::ptr::null()),
-        nShow: SW_SHOWNORMAL,
+        nShow: window.show_command(),
         hInstApp: std::ptr::null_mut(),
         lpIDList: std::ptr::null_mut(),
         lpClass: std::ptr::null(),
@@ -195,6 +233,7 @@ fn platform_run_elevated_and_wait(
     program: &Path,
     arguments: &[String],
     working_directory: Option<&Path>,
+    window: ElevatedWindow,
 ) -> Result<Option<i32>, ElevationError> {
     use std::process::Command;
 
@@ -217,6 +256,12 @@ fn platform_run_elevated_and_wait(
         command_line = command_line
     );
 
+    // `window` has no counterpart here: `do shell script … with
+    // administrator privileges` runs the command with no terminal at all,
+    // which is already what `ElevatedWindow::Hidden` asks for, and macOS
+    // vendor installers are `.pkg` files driven by `installer(8)` rather
+    // than windows RABBIT could show or hide.
+    let _ = window;
     let mut command = Command::new("/usr/bin/osascript");
     command.arg("-e").arg(&script);
     if let Some(working_directory) = working_directory {
@@ -253,6 +298,7 @@ fn platform_run_elevated_and_wait(
     _program: &Path,
     _arguments: &[String],
     _working_directory: Option<&Path>,
+    _window: ElevatedWindow,
 ) -> Result<Option<i32>, ElevationError> {
     Err(ElevationError::Unsupported)
 }
@@ -352,6 +398,8 @@ fn quote_one(argument: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
+    use super::ElevatedWindow;
     use super::quote_arguments;
 
     #[test]
@@ -381,5 +429,18 @@ mod tests {
     fn skips_quoting_for_simple_arguments() {
         assert_eq!(quote_arguments(&["/S".to_string()]), "/S");
         assert_eq!(quote_arguments(&[]), "");
+    }
+
+    /// The two values must map to different show commands, and `Hidden` must
+    /// be the one that draws nothing. Getting this backwards is invisible in
+    /// review and shows up only as a console window flashing on a user's
+    /// screen mid-install, which is the bug this enum exists to fix.
+    #[cfg(windows)]
+    #[test]
+    fn hidden_maps_to_the_show_command_that_draws_nothing() {
+        use windows_sys::Win32::UI::WindowsAndMessaging::{SW_HIDE, SW_SHOWNORMAL};
+
+        assert_eq!(ElevatedWindow::Hidden.show_command(), SW_HIDE);
+        assert_eq!(ElevatedWindow::Show.show_command(), SW_SHOWNORMAL);
     }
 }

--- a/crates/rabbit-platform/src/lib.rs
+++ b/crates/rabbit-platform/src/lib.rs
@@ -19,6 +19,7 @@ pub mod jaws;
 pub mod komplete_kontrol;
 pub mod locale;
 pub mod paths;
+pub mod process;
 pub mod registry;
 pub mod signature;
 
@@ -28,7 +29,9 @@ pub use disk_image::{
     DiskImageError, MountedDiskImage, copy_directory_recursive, find_app_bundle_in_directory,
     install_app_bundle_from_disk_image, mount_disk_image, run_pkg_installer_from_disk_image,
 };
-pub use elevation::{ElevationError, is_nsis_destination_argument, run_elevated_and_wait};
+pub use elevation::{
+    ElevatedWindow, ElevationError, is_nsis_destination_argument, run_elevated_and_wait,
+};
 pub use file_version::{
     read_file_version_parts, read_file_version_string, read_string_file_info_key,
 };

--- a/crates/rabbit-platform/src/process.rs
+++ b/crates/rabbit-platform/src/process.rs
@@ -1,0 +1,70 @@
+//! Shared spawning helpers for the places RABBIT shells out to a helper
+//! program.
+//!
+//! RABBIT's release GUI build targets the Windows GUI subsystem, so the
+//! process owns no console. That is what keeps a console from flashing up
+//! when the user double-clicks RABBIT — but it also means that every time
+//! RABBIT launches a *console* program, Windows has no console to lend the
+//! child and creates a fresh one for it. The user sees a black window pop
+//! up and vanish, usually mid-install, with nothing to explain it.
+//!
+//! Every helper RABBIT runs on Windows is a console program whose output it
+//! reads through pipes, never something the user is meant to watch, so none
+//! of them should get a window. The vendor installers are the exception,
+//! and they are GUI programs launched through
+//! [`crate::elevation::run_elevated_and_wait`] instead.
+
+use std::process::Command;
+
+/// Run a console-subsystem child with no console window.
+///
+/// Only the console *window* is suppressed. Handles redirected through
+/// `Stdio` pipes still work, which is how every caller reads its results —
+/// so this changes what the user sees and nothing else.
+///
+/// No-op off Windows, where a child process never brings its own terminal.
+pub fn without_console_window(command: &mut Command) -> &mut Command {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        /// `CREATE_NO_WINDOW` from `winbase.h`. Hardcoded rather than
+        /// pulled from `windows-sys` because this crate's Windows surface
+        /// is otherwise the Shell and VersionInfo APIs, and one process
+        /// creation flag does not justify another feature on that
+        /// dependency.
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The flag must suppress the console window without costing the caller
+    /// the output it was after. Every site that uses this reads the child
+    /// through a pipe, so a version of this that also detached stdout would
+    /// silently turn signature checks and Defender queries into no-ops.
+    #[test]
+    fn a_windowless_child_still_delivers_its_piped_output() {
+        let mut command = if cfg!(windows) {
+            let mut command = Command::new("cmd");
+            command.args(["/C", "echo", "rabbit"]);
+            command
+        } else {
+            let mut command = Command::new("/bin/echo");
+            command.arg("rabbit");
+            command
+        };
+
+        let output = without_console_window(&mut command)
+            .output()
+            .expect("the helper process should run");
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "rabbit");
+    }
+}

--- a/crates/rabbit-platform/src/signature.rs
+++ b/crates/rabbit-platform/src/signature.rs
@@ -72,12 +72,11 @@ fn verify_executable_signature_impl(path: &Path) -> std::io::Result<SignatureVer
         });
     };
 
-    let output = Command::new(&signtool)
-        .arg("verify")
-        .arg("/pa")
-        .arg("/q")
-        .arg(path)
-        .output()?;
+    // `signtool` is a console program and its output is read through the
+    // pipe below, so a console window would be pure noise on screen.
+    let mut command = Command::new(&signtool);
+    command.arg("verify").arg("/pa").arg("/q").arg(path);
+    let output = crate::process::without_console_window(&mut command).output()?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();

--- a/crates/rabbit-ui-wxdragon/Cargo.toml
+++ b/crates/rabbit-ui-wxdragon/Cargo.toml
@@ -10,6 +10,10 @@ gui = ["dep:wxdragon"]
 
 [dependencies]
 rabbit-core = { path = "../rabbit-core" }
+# Only for `process::without_console_window`: the wizard opens external URLs
+# through `cmd /C start` on Windows, which needs the same console-window
+# suppression as the helpers rabbit-core runs.
+rabbit-platform = { path = "../rabbit-platform" }
 serde.workspace = true
 wxdragon = { workspace = true, optional = true }
 

--- a/crates/rabbit-ui-wxdragon/src/wx_app.rs
+++ b/crates/rabbit-ui-wxdragon/src/wx_app.rs
@@ -5872,7 +5872,13 @@ fn build_reapack_ack_page(page: &Panel, model: &WizardModel) -> (Button, CheckBo
 fn open_external_url(url: &str) -> std::io::Result<()> {
     #[cfg(target_os = "windows")]
     {
-        Command::new("cmd").args(["/C", "start", "", url]).spawn()?;
+        // `cmd` is a console program, and RABBIT's release build owns no
+        // console to lend it, so without this a black window flashes up
+        // every time the user follows a link. The browser `start` hands the
+        // URL to is a separate process and still opens normally.
+        let mut command = Command::new("cmd");
+        command.args(["/C", "start", "", url]);
+        rabbit_platform::process::without_console_window(&mut command).spawn()?;
         Ok(())
     }
 


### PR DESCRIPTION
The release build sets `windows_subsystem = "windows"`, which is what stops a console appearing when someone double-clicks RABBIT. The other half of that is easy to miss: the process then owns no console at all, so every time RABBIT launches a **console** program, Windows has none to lend the child and creates a fresh console window for it. The user sees a black window flash up and vanish, mid-install, with nothing to explain it.

Three places did that. The one behind the report is the Defender exclusion.

### What was flashing

| Program | When | Why "sometimes" |
| --- | --- | --- |
| `powershell.exe` | Adding the `%TEMP%\rabbit-cache` Defender exclusion | Only on runs that actually need the exclusion — it is skipped once the read (or the marker) says it is already there |
| `signtool.exe` | Verifying a downloaded installer's signature | Only on machines with the Windows SDK, so maintainers see it and most users never do |
| `cmd.exe` | `cmd /C start "" <url>`, opening any link in the wizard | Every time, but it is a link click rather than an install |

The unelevated Defender *read* was already correct — it has carried `CREATE_NO_WINDOW` since it was written. It was the elevated *add* that showed, and that one goes through `ShellExecuteExW`, where `creation_flags` does not apply and `nShow` was hardcoded to `SW_SHOWNORMAL`.

That is also why the existing `-WindowStyle Hidden` on the PowerShell command line wasn't enough: it only takes effect once the PowerShell host is already up, by which point the console window has been created and shown. It stays in as a second line of defence, but `nShow` is what actually decides.

### What changes

- `rabbit_platform::process::without_console_window` — one documented home for `CREATE_NO_WINDOW`, replacing the constant that `defender.rs` had defined locally, and now also applied to `signtool` and to `cmd /C start`.
- `ElevatedWindow::{Show, Hidden}` on `run_elevated_and_wait`, feeding `nShow`. The Defender add passes `Hidden`; the vendor installers pass `Show`.

Vendor installers keep their windows on purpose. Even the ones RABBIT drives silently can fall back to their own progress or error windows, and suppressing those would leave the user in front of a wizard that had apparently stalled. Making it an explicit argument means that decision is now written down at both call sites instead of being one hardcoded constant serving two very different needs.

The UAC consent dialog is drawn by the system on its own desktop and is unaffected by `nShow`, so hiding the child never hides the prompt.

### Not changed

The unelevated vendor-installer path in `execute_program_plan` keeps its plain `Command`. Every Windows installer RABBIT runs today is GUI-subsystem (NSIS for REAPER, OSARA, SWS and the JAWS scripts; Inno for Surge XT), so none of them produce a console to suppress — and the same code path serves the CLI, where detaching a child's console could hide output someone wanted.

### Testing

`cargo fmt --check` clean, clippy clean in both configurations, 437 tests pass, `cargo build -p rabbit --features gui` links.

Two new tests:

- `ElevatedWindow::Hidden` maps to `SW_HIDE` and `Show` to `SW_SHOWNORMAL`. Worth pinning: getting it backwards is invisible in review and surfaces only as a window flashing on a user's screen.
- a child spawned through `without_console_window` still delivers its piped stdout. That is the risk this change carries — every caller reads its helper through a pipe, so a version that also detached stdout would quietly turn signature checks and Defender queries into no-ops.

`cargo check -p rabbit-platform --target aarch64-apple-darwin` passes as well. The macOS `platform_run_elevated_and_wait` and the `installer(8)` call in `disk_image.rs` both needed the new argument, and neither is visible to a Windows build.
